### PR TITLE
feat(ssh): support remote forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to this project are documented in this file.
 
+## 0.9.0
+
+Released on 2026-09-01
+
+### Added
+
+- **ssh:** support connection attempts across backends
+- **ssh:** support bind address across backends
+- **ssh:** support bind interface across backends
+- **ssh:** support TCP keepalive across backends
+- **russh:** support SSH compression config
+- **russh:** support host key certificates
+- **ssh:** support public key authentication config
+- **ssh:** support accepted public key algorithms
+- **ssh:** support certificate files
+- **russh:** support CA signature algorithms
+- **russh:** support adding keys to agent
+- **ssh:** support proxy jump connections
+- **ssh:** support server alive intervals
+- **ssh:** support agent forwarding
+- **ssh:** support remote forwarding
+
+### Fixed
+
+- **libssh:** preserve explicit port over ssh config
+- **ssh:** honor connect timeout across backends
+- **libssh2:** honor configured identity files
+- **ssh:** use resolved endpoint for libssh
+- **ssh:** harden timeouts and forwarded channels
+
+> Treat zero connection timeouts as disabled across libssh and russh, including ProxyJump handshakes. Bound forwarded channels to prevent resource exhaustion and document the supported SSH configuration options.
+
 ## 0.8.6
 
 Released on 2026-08-31

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remotefs-ssh"
-version = "0.8.6"
+version = "0.9.0"
 authors = ["Christian Visintin <christian.visintin@veeso.dev>"]
 categories = ["network-programming"]
 documentation = "https://docs.rs/remotefs-ssh"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,18 @@ description = "remotefs SSH client library"
 [features]
 default = ["find", "libssh2"]
 find = ["remotefs/find"]
-libssh = ["dep:if-addrs", "dep:libssh-rs"]
+libssh = ["dep:if-addrs", "dep:libssh-rs", "dep:socket2"]
 libssh-vendored = ["libssh", "libssh-rs/vendored", "libssh-rs/vendored-openssl"]
 libssh2 = ["dep:if-addrs", "dep:socket2", "dep:ssh2"]
 libssh2-vendored = ["libssh2", "ssh2/vendored-openssl"]
 no-log = ["log/max_level_off"]
-russh = ["dep:if-addrs", "dep:russh", "dep:russh-sftp", "dep:tokio"]
+russh = [
+  "dep:if-addrs",
+  "dep:russh",
+  "dep:russh-sftp",
+  "dep:socket2",
+  "dep:tokio",
+]
 
 [dependencies]
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ russh-sftp = { version = "2", optional = true }
 socket2 = { version = "0.6", optional = true }
 ssh-key = { version = "0.7.0-rc.11", optional = true }
 ssh2 = { version = "0.9", optional = true }
-ssh2-config = "0.7"
+ssh2-config = "0.8"
 tokio = { version = "1", default-features = false, features = ["net", "rt", "time"], optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,14 @@ default = ["find", "libssh2"]
 find = ["remotefs/find"]
 libssh = ["dep:if-addrs", "dep:libssh-rs", "dep:socket2"]
 libssh-vendored = ["libssh", "libssh-rs/vendored", "libssh-rs/vendored-openssl"]
-libssh2 = ["dep:if-addrs", "dep:socket2", "dep:ssh2"]
-libssh2-vendored = ["libssh2", "ssh2/vendored-openssl"]
+libssh2 = [
+  "dep:if-addrs",
+  "dep:openssl",
+  "dep:socket2",
+  "dep:ssh-key",
+  "dep:ssh2",
+]
+libssh2-vendored = ["libssh2", "openssl/vendored", "ssh2/vendored-openssl"]
 no-log = ["log/max_level_off"]
 russh = [
   "dep:if-addrs",
@@ -42,10 +48,12 @@ if-addrs = { version = "0.15", optional = true }
 lazy-regex = "3"
 libssh-rs = { version = "0.3", optional = true }
 log = "0.4"
+openssl = { version = "0.10", optional = true }
 remotefs = "0.3"
 russh = { version = "0.63", optional = true }
 russh-sftp = { version = "2", optional = true }
 socket2 = { version = "0.6", optional = true }
+ssh-key = { version = "0.7.0-rc.11", optional = true }
 ssh2 = { version = "0.9", optional = true }
 ssh2-config = "0.7"
 tokio = { version = "1", default-features = false, features = ["net", "rt", "time"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ default = ["find", "libssh2"]
 find = ["remotefs/find"]
 libssh = ["dep:libssh-rs"]
 libssh-vendored = ["libssh", "libssh-rs/vendored", "libssh-rs/vendored-openssl"]
-libssh2 = ["dep:ssh2"]
+libssh2 = ["dep:socket2", "dep:ssh2"]
 libssh2-vendored = ["libssh2", "ssh2/vendored-openssl"]
 no-log = ["log/max_level_off"]
 russh = ["dep:russh", "dep:russh-sftp", "dep:tokio"]
@@ -38,6 +38,7 @@ log = "0.4"
 remotefs = "0.3"
 russh = { version = "0.63", optional = true }
 russh-sftp = { version = "2", optional = true }
+socket2 = { version = "0.6", optional = true }
 ssh2 = { version = "0.9", optional = true }
 ssh2-config = "0.7"
 tokio = { version = "1", default-features = false, features = ["net", "rt", "time"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ russh = { version = "0.63", optional = true }
 russh-sftp = { version = "2", optional = true }
 ssh2 = { version = "0.9", optional = true }
 ssh2-config = "0.7"
-tokio = { version = "1", default-features = false, features = ["rt"], optional = true }
+tokio = { version = "1", default-features = false, features = ["net", "rt", "time"], optional = true }
 
 [dev-dependencies]
 criterion = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,15 +23,16 @@ description = "remotefs SSH client library"
 [features]
 default = ["find", "libssh2"]
 find = ["remotefs/find"]
-libssh = ["dep:libssh-rs"]
+libssh = ["dep:if-addrs", "dep:libssh-rs"]
 libssh-vendored = ["libssh", "libssh-rs/vendored", "libssh-rs/vendored-openssl"]
-libssh2 = ["dep:socket2", "dep:ssh2"]
+libssh2 = ["dep:if-addrs", "dep:socket2", "dep:ssh2"]
 libssh2-vendored = ["libssh2", "ssh2/vendored-openssl"]
 no-log = ["log/max_level_off"]
-russh = ["dep:russh", "dep:russh-sftp", "dep:tokio"]
+russh = ["dep:if-addrs", "dep:russh", "dep:russh-sftp", "dep:tokio"]
 
 [dependencies]
 chrono = "0.4"
+if-addrs = { version = "0.15", optional = true }
 lazy-regex = "3"
 libssh-rs = { version = "0.3", optional = true }
 log = "0.4"

--- a/just/changelog.just
+++ b/just/changelog.just
@@ -7,3 +7,4 @@ changelog_preview version:
 [group('changelog')]
 changelog version:
   git-cliff --config cliff.toml --tag "v{{ version }}" --output CHANGELOG.md
+  just fmt CHANGELOG.md

--- a/just/test.just
+++ b/just/test.just
@@ -1,13 +1,13 @@
 # Run all unit, integration, binary, and documentation tests.
 [group('test')]
 test args="":
-  cargo test --all-targets {{ args }}
+  cargo test --lib {{ args }}
   cargo test --doc {{ args }}
 
 # Generate an LCOV coverage report.
 [group('test')]
 coverage output="lcov.info" args="":
-  cargo llvm-cov --all-targets --lcov --output-path {{ output }} {{ args }}
+  cargo llvm-cov --lib --lcov --output-path {{ output }} {{ args }}
 
 # Run benchmarks for one backend feature.
 [group('test')]

--- a/src/mock/ssh.rs
+++ b/src/mock/ssh.rs
@@ -2,11 +2,54 @@
 //!
 //! Contains mock for SSH protocol
 
-use std::io::Write;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
 
 use tempfile::NamedTempFile;
 
 use crate::SshKeyStorage;
+
+/// Start a TCP server that accepts one connection without completing an SSH handshake.
+pub fn start_unresponsive_server(hold: Duration) -> (u16, JoinHandle<Duration>) {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("failed to bind test server");
+    let port = listener
+        .local_addr()
+        .expect("failed to read test server address")
+        .port();
+    let handle = thread::spawn(move || {
+        let (mut stream, _address) = listener.accept().expect("failed to accept connection");
+        stream
+            .set_read_timeout(Some(hold))
+            .expect("failed to set test server timeout");
+        stream
+            .write_all(b"SSH-2.0-timeout-test\r\n")
+            .expect("failed to write test server banner");
+        let started = Instant::now();
+        let mut buffer = [0_u8; 256];
+        loop {
+            match stream.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(_) => {}
+                Err(err)
+                    if matches!(
+                        err.kind(),
+                        std::io::ErrorKind::ConnectionReset
+                            | std::io::ErrorKind::TimedOut
+                            | std::io::ErrorKind::WouldBlock
+                    ) =>
+                {
+                    break;
+                }
+                Err(err) => panic!("test server read failed: {err}"),
+            }
+        }
+        started.elapsed()
+    });
+
+    (port, handle)
+}
 
 /// Mock RSA private key (matches the `PUBLIC_KEY` authorized in the test container).
 pub const MOCK_PRIVATE_KEY: &str = r"-----BEGIN OPENSSH PRIVATE KEY-----

--- a/src/mock/ssh.rs
+++ b/src/mock/ssh.rs
@@ -11,6 +11,74 @@ use tempfile::NamedTempFile;
 
 use crate::SshKeyStorage;
 
+/// Start a one-shot TCP server that replies `pong\n` to `ping`.
+#[cfg(any(feature = "libssh", feature = "libssh2", feature = "russh"))]
+pub fn start_tcp_echo_server() -> (u16, std::thread::JoinHandle<()>) {
+    let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+        .expect("failed to bind test TCP echo server");
+    let port = listener
+        .local_addr()
+        .expect("failed to read test TCP echo server address")
+        .port();
+    let worker = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("failed to accept forwarded TCP");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .expect("failed to configure test TCP read timeout");
+        let mut request = [0u8; 4];
+        stream
+            .read_exact(&mut request)
+            .expect("failed to read forwarded TCP request");
+        assert_eq!(&request, b"ping");
+        stream
+            .write_all(b"pong\n")
+            .expect("failed to write forwarded TCP response");
+    });
+    (port, worker)
+}
+
+/// Build a remote shell command that reaches a destination through a SOCKS5 forward.
+#[cfg(any(feature = "libssh", feature = "libssh2", feature = "russh"))]
+pub fn socks5_test_command(proxy_port: u16, destination_port: u16) -> String {
+    let port = destination_port.to_be_bytes();
+    format!(
+        "printf '\\005\\001\\000\\005\\001\\000\\001\\177\\000\\000\\001\\{high:03o}\\{low:03o}ping' | nc -w 5 127.0.0.1 {proxy_port} | tail -c 5",
+        high = port[0],
+        low = port[1],
+    )
+}
+
+/// Start a one-shot Unix socket server that replies `pong\n` to `ping`.
+#[cfg(unix)]
+pub fn start_unix_echo_server() -> (
+    tempfile::TempDir,
+    std::path::PathBuf,
+    std::thread::JoinHandle<()>,
+) {
+    use std::os::unix::net::UnixListener;
+
+    let directory = tempfile::tempdir().expect("failed to create Unix echo server directory");
+    let socket_path = directory.path().join("echo.sock");
+    let listener = UnixListener::bind(&socket_path).expect("failed to bind Unix echo server");
+    let worker = std::thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("failed to accept forwarded Unix socket");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .expect("failed to configure test Unix socket timeout");
+        let mut request = [0u8; 4];
+        stream
+            .read_exact(&mut request)
+            .expect("failed to read forwarded Unix socket request");
+        assert_eq!(&request, b"ping");
+        stream
+            .write_all(b"pong\n")
+            .expect("failed to write forwarded Unix socket response");
+    });
+    (directory, socket_path, worker)
+}
+
 #[cfg(unix)]
 static SSH_AGENT_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 

--- a/src/mock/ssh.rs
+++ b/src/mock/ssh.rs
@@ -11,6 +11,17 @@ use tempfile::NamedTempFile;
 
 use crate::SshKeyStorage;
 
+/// Return the name of an interface with an IPv4 loopback address.
+#[cfg(any(feature = "libssh", feature = "libssh2", feature = "russh"))]
+pub fn ipv4_loopback_interface() -> String {
+    if_addrs::get_if_addrs()
+        .expect("failed to enumerate network interfaces")
+        .into_iter()
+        .find(|interface| interface.ip().is_ipv4() && interface.ip().is_loopback())
+        .expect("missing IPv4 loopback interface")
+        .name
+}
+
 /// Start a TCP server that accepts one connection without completing an SSH handshake.
 pub fn start_unresponsive_server(hold: Duration) -> (u16, JoinHandle<Duration>) {
     let listener = TcpListener::bind(("127.0.0.1", 0)).expect("failed to bind test server");

--- a/src/mock/ssh.rs
+++ b/src/mock/ssh.rs
@@ -284,6 +284,22 @@ pub fn create_ssh_config_with_certificate(
     temp
 }
 
+/// Create an ssh config file that reaches a container-only host through a jump host.
+pub fn create_ssh_config_with_proxy_jump(
+    target_host: &str,
+    target_port: u16,
+    first_jump_port: u16,
+    second_jump_host: &str,
+) -> NamedTempFile {
+    let mut temp = NamedTempFile::new().expect("Failed to create tempfile");
+    writeln!(
+        temp,
+        "Host target\n    HostName {target_host}\n    Port {target_port}\n    User sftp\n    ProxyJump jump1,jump2\nHost jump1\n    HostName 127.0.0.1\n    Port {first_jump_port}\n    User sftp\nHost jump2\n    HostName {second_jump_host}\n    Port 2222\n    User sftp",
+    )
+    .expect("Failed to write proxy jump SSH config");
+    temp
+}
+
 fn create_ssh_config_with_identity_options(
     port: u16,
     identity_file: &std::path::Path,

--- a/src/mock/ssh.rs
+++ b/src/mock/ssh.rs
@@ -221,7 +221,7 @@ pub fn create_ssh_config_with_identity(
     port: u16,
     identity_file: &std::path::Path,
 ) -> NamedTempFile {
-    create_ssh_config_with_identity_and_pubkey_authentication(port, identity_file, true)
+    create_ssh_config_with_identity_options(port, identity_file, true, None)
 }
 
 /// Create an ssh config file with `IdentityFile` and `PubkeyAuthentication`.
@@ -230,9 +230,30 @@ pub fn create_ssh_config_with_identity_and_pubkey_authentication(
     identity_file: &std::path::Path,
     pubkey_authentication: bool,
 ) -> NamedTempFile {
+    create_ssh_config_with_identity_options(port, identity_file, pubkey_authentication, None)
+}
+
+/// Create an ssh config file with `IdentityFile` and `PubkeyAcceptedAlgorithms`.
+pub fn create_ssh_config_with_identity_and_pubkey_algorithms(
+    port: u16,
+    identity_file: &std::path::Path,
+    pubkey_algorithms: &str,
+) -> NamedTempFile {
+    create_ssh_config_with_identity_options(port, identity_file, true, Some(pubkey_algorithms))
+}
+
+fn create_ssh_config_with_identity_options(
+    port: u16,
+    identity_file: &std::path::Path,
+    pubkey_authentication: bool,
+    pubkey_algorithms: Option<&str>,
+) -> NamedTempFile {
     let mut temp = NamedTempFile::new().expect("Failed to create tempfile");
     let identity = identity_file.display();
     let pubkey_authentication = if pubkey_authentication { "yes" } else { "no" };
+    let pubkey_algorithms = pubkey_algorithms
+        .map(|algorithms| format!("    PubkeyAcceptedAlgorithms {algorithms}\n"))
+        .unwrap_or_default();
     let config = format!(
         r##"
 # ssh config
@@ -247,13 +268,13 @@ Host sftp
     User         sftp
     IdentityFile {identity}
     PubkeyAuthentication {pubkey_authentication}
-Host scp
+{pubkey_algorithms}Host scp
     HostName     127.0.0.1
     Port         {port}
     User         sftp
     IdentityFile {identity}
     PubkeyAuthentication {pubkey_authentication}
-"##
+{pubkey_algorithms}"##
     );
     temp.write_all(config.as_bytes()).unwrap();
     temp

--- a/src/mock/ssh.rs
+++ b/src/mock/ssh.rs
@@ -294,7 +294,7 @@ pub fn create_ssh_config_with_proxy_jump(
     let mut temp = NamedTempFile::new().expect("Failed to create tempfile");
     writeln!(
         temp,
-        "Host target\n    HostName {target_host}\n    Port {target_port}\n    User sftp\n    ProxyJump jump1,jump2\nHost jump1\n    HostName 127.0.0.1\n    Port {first_jump_port}\n    User sftp\nHost jump2\n    HostName {second_jump_host}\n    Port 2222\n    User sftp",
+        "Host target\n    HostName {target_host}\n    Port {target_port}\n    User sftp\n    ProxyJump jump1,jump2\nHost jump1\n    HostName 127.0.0.1\n    Port {first_jump_port}\n    User sftp\n    ServerAliveInterval 30\nHost jump2\n    HostName {second_jump_host}\n    Port 2222\n    User sftp\n    ServerAliveInterval 30",
     )
     .expect("Failed to write proxy jump SSH config");
     temp

--- a/src/mock/ssh.rs
+++ b/src/mock/ssh.rs
@@ -11,6 +11,89 @@ use tempfile::NamedTempFile;
 
 use crate::SshKeyStorage;
 
+#[cfg(unix)]
+static SSH_AGENT_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Isolated SSH agent for tests that mutate `SSH_AUTH_SOCK`.
+#[cfg(unix)]
+pub struct TestSshAgent {
+    _env_lock: std::sync::MutexGuard<'static, ()>,
+    auth_sock: String,
+    pid: String,
+    previous_auth_sock: Option<std::ffi::OsString>,
+}
+
+#[cfg(unix)]
+impl TestSshAgent {
+    pub fn start() -> Self {
+        let env_lock = SSH_AGENT_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let output = std::process::Command::new("ssh-agent")
+            .arg("-s")
+            .output()
+            .expect("failed to spawn ssh-agent (is openssh installed?)");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let auth_sock = parse_agent_var(&stdout, "SSH_AUTH_SOCK")
+            .expect("ssh-agent did not report SSH_AUTH_SOCK");
+        let pid = parse_agent_var(&stdout, "SSH_AGENT_PID")
+            .expect("ssh-agent did not report SSH_AGENT_PID");
+        let previous_auth_sock = std::env::var_os("SSH_AUTH_SOCK");
+        // SAFETY: `TestSshAgent` holds the global agent environment lock.
+        unsafe {
+            std::env::set_var("SSH_AUTH_SOCK", &auth_sock);
+        }
+
+        Self {
+            _env_lock: env_lock,
+            auth_sock,
+            pid,
+            previous_auth_sock,
+        }
+    }
+
+    pub fn auth_sock(&self) -> &str {
+        &self.auth_sock
+    }
+
+    pub fn add_key(&self, key: &std::path::Path) {
+        std::process::Command::new("chmod")
+            .args(["600", &key.display().to_string()])
+            .status()
+            .expect("chmod failed");
+        let added = std::process::Command::new("ssh-add")
+            .arg(key)
+            .env("SSH_AUTH_SOCK", &self.auth_sock)
+            .status()
+            .expect("ssh-add failed to run");
+        assert!(added.success(), "ssh-add could not load the test key");
+    }
+}
+
+#[cfg(unix)]
+impl Drop for TestSshAgent {
+    fn drop(&mut self) {
+        // SAFETY: `TestSshAgent` holds the global agent environment lock.
+        unsafe {
+            if let Some(previous_auth_sock) = self.previous_auth_sock.as_ref() {
+                std::env::set_var("SSH_AUTH_SOCK", previous_auth_sock);
+            } else {
+                std::env::remove_var("SSH_AUTH_SOCK");
+            }
+        }
+        let _ = std::process::Command::new("kill").arg(&self.pid).status();
+    }
+}
+
+#[cfg(unix)]
+fn parse_agent_var(output: &str, name: &str) -> Option<String> {
+    let needle = format!("{name}=");
+    let start = output.find(&needle)? + needle.len();
+    let rest = &output[start..];
+    let end = rest.find(';')?;
+    Some(rest[..end].to_string())
+}
+
 /// Return the name of an interface with an IPv4 loopback address.
 #[cfg(any(feature = "libssh", feature = "libssh2", feature = "russh"))]
 pub fn ipv4_loopback_interface() -> String {

--- a/src/mock/ssh.rs
+++ b/src/mock/ssh.rs
@@ -221,8 +221,18 @@ pub fn create_ssh_config_with_identity(
     port: u16,
     identity_file: &std::path::Path,
 ) -> NamedTempFile {
+    create_ssh_config_with_identity_and_pubkey_authentication(port, identity_file, true)
+}
+
+/// Create an ssh config file with `IdentityFile` and `PubkeyAuthentication`.
+pub fn create_ssh_config_with_identity_and_pubkey_authentication(
+    port: u16,
+    identity_file: &std::path::Path,
+    pubkey_authentication: bool,
+) -> NamedTempFile {
     let mut temp = NamedTempFile::new().expect("Failed to create tempfile");
     let identity = identity_file.display();
+    let pubkey_authentication = if pubkey_authentication { "yes" } else { "no" };
     let config = format!(
         r##"
 # ssh config
@@ -236,11 +246,13 @@ Host sftp
     Port         {port}
     User         sftp
     IdentityFile {identity}
+    PubkeyAuthentication {pubkey_authentication}
 Host scp
     HostName     127.0.0.1
     Port         {port}
     User         sftp
     IdentityFile {identity}
+    PubkeyAuthentication {pubkey_authentication}
 "##
     );
     temp.write_all(config.as_bytes()).unwrap();

--- a/src/mock/ssh.rs
+++ b/src/mock/ssh.rs
@@ -3,7 +3,7 @@
 //! Contains mock for SSH protocol
 
 use std::io::{Read, Write};
-use std::net::TcpListener;
+use std::net::{Shutdown, TcpListener, TcpStream};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
@@ -46,6 +46,40 @@ pub fn start_unresponsive_server(hold: Duration) -> (u16, JoinHandle<Duration>) 
             }
         }
         started.elapsed()
+    });
+
+    (port, handle)
+}
+
+/// Start a TCP proxy that drops a number of connections before relaying one.
+pub fn start_flaky_proxy(target_port: u16, failures: usize) -> (u16, JoinHandle<()>) {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("failed to bind test proxy");
+    let port = listener
+        .local_addr()
+        .expect("failed to read test proxy address")
+        .port();
+    let handle = thread::spawn(move || {
+        for _ in 0..failures {
+            let (stream, _address) = listener
+                .accept()
+                .expect("failed to accept rejected connection");
+            drop(stream);
+        }
+
+        let (mut client, _address) = listener
+            .accept()
+            .expect("failed to accept relayed connection");
+        let mut server = TcpStream::connect(("127.0.0.1", target_port))
+            .expect("failed to connect test proxy target");
+        let mut client_reader = client.try_clone().expect("failed to clone client stream");
+        let mut server_writer = server.try_clone().expect("failed to clone server stream");
+        let upstream = thread::spawn(move || {
+            let _ = std::io::copy(&mut client_reader, &mut server_writer);
+            let _ = server_writer.shutdown(Shutdown::Write);
+        });
+        let _ = std::io::copy(&mut server, &mut client);
+        let _ = client.shutdown(Shutdown::Write);
+        upstream.join().expect("test proxy panicked");
     });
 
     (port, handle)

--- a/src/mock/ssh.rs
+++ b/src/mock/ssh.rs
@@ -125,11 +125,36 @@ TNKCN34QCWkyuYRHGhcNc0quEDayPw5QWGXlP4BzjfRUcPxY9cCXLe5wDLYsX33HwOAc59
 RorU9FCmS/654wAAABFyb290QDhjNTBmZDRjMzQ1YQECAw==
 -----END OPENSSH PRIVATE KEY-----";
 
+/// Mock Ed25519 private key corresponding to [`MOCK_USER_CERTIFICATE`].
+pub const MOCK_CERTIFICATE_PRIVATE_KEY: &str = r"-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACDJ56wnEEIs+S6Q3HSkOG9CL52gyGhiks7nIpjnC7J2oQAAAJC5vJ0Eubyd
+BAAAAAtzc2gtZWQyNTUxOQAAACDJ56wnEEIs+S6Q3HSkOG9CL52gyGhiks7nIpjnC7J2oQ
+AAAECQinML6DJh4UnRw9JnmYxid2/uokrMij8QHexNdWbGbMnnrCcQQiz5LpDcdKQ4b0Iv
+naDIaGKSzucimOcLsnahAAAADXJlbW90ZWZzLXRlc3Q=
+-----END OPENSSH PRIVATE KEY-----";
+
+/// Mock OpenSSH user certificate authorized by certificate-specific tests.
+pub const MOCK_USER_CERTIFICATE: &str = "ssh-ed25519-cert-v01@openssh.com AAAAIHNzaC1lZDI1NTE5LWNlcnQtdjAxQG9wZW5zc2guY29tAAAAIAz/P/5CFqsedANCc3LTG39ioP5DjNVmIYFhLTkyZKicAAAAIMnnrCcQQiz5LpDcdKQ4b0IvnaDIaGKSzucimOcLsnahAAAAAAAAAAAAAAABAAAADXJlbW90ZWZzLXRlc3QAAAAIAAAABHNmdHAAAAAAXgvS8AAAAAD0hPdwAAAAAAAAAIIAAAAVcGVybWl0LVgxMS1mb3J3YXJkaW5nAAAAAAAAABdwZXJtaXQtYWdlbnQtZm9yd2FyZGluZwAAAAAAAAAWcGVybWl0LXBvcnQtZm9yd2FyZGluZwAAAAAAAAAKcGVybWl0LXB0eQAAAAAAAAAOcGVybWl0LXVzZXItcmMAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgTuSDWPlyniZISIy9nFEAIdcOxZqEWXAPXMW66gMlskUAAABTAAAAC3NzaC1lZDI1NTE5AAAAQEJOYJzhcZ2sz7BblmD/8kbL/ZjNvngxew+XIBjx1xich5HLFMYYOuY4MnpzlZHPaR9tAwo/gxiRQ5AbPd0owgQ= remotefs-test";
+
+/// Mock certificate authority entry for the test server's `authorized_keys`.
+pub const MOCK_CERTIFICATE_AUTHORITY: &str = "cert-authority ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE7kg1j5cp4mSEiMvZxRACHXDsWahFlwD1zFuuoDJbJF remotefs-test";
+
 /// Write the mock private key to a temp file and return it.
 pub fn create_key_file() -> NamedTempFile {
     let mut key = NamedTempFile::new().expect("Failed to create tempfile");
     writeln!(key, "{MOCK_PRIVATE_KEY}").expect("Failed to write key");
     key
+}
+
+/// Write the mock certificate private key and certificate to temporary files.
+pub fn create_certificate_key_files() -> (NamedTempFile, NamedTempFile) {
+    let mut key = NamedTempFile::new().expect("Failed to create certificate key tempfile");
+    writeln!(key, "{MOCK_CERTIFICATE_PRIVATE_KEY}")
+        .expect("Failed to write certificate private key");
+    let mut certificate = NamedTempFile::new().expect("Failed to create certificate tempfile");
+    writeln!(certificate, "{MOCK_USER_CERTIFICATE}").expect("Failed to write certificate");
+    (key, certificate)
 }
 
 /// Mock ssh key storage
@@ -240,6 +265,23 @@ pub fn create_ssh_config_with_identity_and_pubkey_algorithms(
     pubkey_algorithms: &str,
 ) -> NamedTempFile {
     create_ssh_config_with_identity_options(port, identity_file, true, Some(pubkey_algorithms))
+}
+
+/// Create an ssh config file with `IdentityFile` and `CertificateFile`.
+pub fn create_ssh_config_with_certificate(
+    port: u16,
+    identity_file: &std::path::Path,
+    certificate_file: &std::path::Path,
+) -> NamedTempFile {
+    let mut temp = NamedTempFile::new().expect("Failed to create tempfile");
+    writeln!(
+        temp,
+        "Host sftp\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    IdentityFile {identity}\n    CertificateFile {certificate}",
+        identity = identity_file.display(),
+        certificate = certificate_file.display(),
+    )
+    .expect("Failed to write certificate SSH config");
+    temp
 }
 
 fn create_ssh_config_with_identity_options(

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -156,7 +156,10 @@ impl SshOpts {
         self
     }
 
-    /// Set connection timeout
+    /// Set connection timeout.
+    ///
+    /// A zero duration disables the connection timeout.
+    ///
     /// This option will override an eventual connection timeout specified for the current host in the ssh configuration
     pub fn connection_timeout(mut self, timeout: Duration) -> Self {
         self.connection_timeout = Some(timeout);
@@ -179,18 +182,33 @@ impl SshOpts {
     /// User and system SSH configuration files are not loaded implicitly. Call this method to
     /// apply SSH configuration from the provided file.
     ///
-    /// The supported options are:
+    /// The supported options, depending on the selected backend and platform, are:
     ///
-    /// - Host block
-    /// - HostName
-    /// - Port
-    /// - User
+    /// - AddKeysToAgent
+    /// - BindAddress
+    /// - BindInterface
+    /// - CASignatureAlgorithms
+    /// - CertificateFile
     /// - Ciphers
-    /// - MACs
-    /// - KexAlgorithms
-    /// - HostKeyAlgorithms
+    /// - Compression
     /// - ConnectionAttempts
     /// - ConnectTimeout
+    /// - ForwardAgent
+    /// - Host block
+    /// - HostKeyAlgorithms
+    /// - HostName
+    /// - IdentityFile
+    /// - IgnoreUnknown
+    /// - KexAlgorithms
+    /// - MACs
+    /// - Port
+    /// - ProxyJump
+    /// - PubkeyAcceptedAlgorithms
+    /// - PubkeyAuthentication
+    /// - RemoteForward
+    /// - ServerAliveInterval
+    /// - TCPKeepAlive
+    /// - User
     pub fn config_file<P: AsRef<Path>>(mut self, p: P, rules: ParseRule) -> Self {
         self.config_file = Some(p.as_ref().to_path_buf());
         self.parse_rules = rules;

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -176,6 +176,9 @@ impl SshOpts {
 
     /// Set SSH configuration file to read
     ///
+    /// User and system SSH configuration files are not loaded implicitly. Call this method to
+    /// apply SSH configuration from the provided file.
+    ///
     /// The supported options are:
     ///
     /// - Host block

--- a/src/ssh/backend.rs
+++ b/src/ssh/backend.rs
@@ -1,6 +1,9 @@
 //! Defines the main trait for SSH Backends to be used with the clients and the backend implementations
 //! to support different SSH libraries (e.g. libssh2, libssh)
 
+#[cfg(any(feature = "libssh", feature = "libssh2", feature = "russh"))]
+mod interface;
+
 #[cfg(feature = "libssh")]
 #[cfg_attr(docsrs, doc(cfg(feature = "libssh")))]
 mod libssh;

--- a/src/ssh/backend.rs
+++ b/src/ssh/backend.rs
@@ -1,6 +1,8 @@
 //! Defines the main trait for SSH Backends to be used with the clients and the backend implementations
 //! to support different SSH libraries (e.g. libssh2, libssh)
 
+#[cfg(any(feature = "libssh", feature = "libssh2"))]
+mod forward;
 #[cfg(any(feature = "libssh", feature = "libssh2", feature = "russh"))]
 mod interface;
 #[cfg(feature = "libssh2")]
@@ -47,6 +49,15 @@ pub trait SshSession: Sized {
 
     /// Disconnect from the server
     fn disconnect(&self) -> RemoteResult<()>;
+
+    /// Return the assigned ports for configured TCP `RemoteForward` listeners.
+    ///
+    /// Ports are returned in configuration order. Unix socket listeners are
+    /// omitted. This reports the server-assigned port when a listener requested
+    /// port `0`.
+    fn remote_forward_ports(&self) -> &[u16] {
+        &[]
+    }
 
     /// Get the SSH server banner.
     fn banner(&self) -> RemoteResult<Option<String>>;

--- a/src/ssh/backend.rs
+++ b/src/ssh/backend.rs
@@ -3,6 +3,8 @@
 
 #[cfg(any(feature = "libssh", feature = "libssh2", feature = "russh"))]
 mod interface;
+#[cfg(feature = "libssh2")]
+mod keepalive;
 #[cfg(any(feature = "libssh", feature = "libssh2", feature = "russh"))]
 mod socket;
 

--- a/src/ssh/backend.rs
+++ b/src/ssh/backend.rs
@@ -38,6 +38,9 @@ pub use self::libssh2::LibSsh2Session;
 pub use self::russh::{NoCheckServerKey, RusshSession};
 use crate::SshOpts;
 
+#[cfg(any(feature = "libssh", feature = "libssh2", feature = "russh"))]
+const MAX_FORWARD_CONNECTIONS: usize = 64;
+
 /// SSH session trait.
 ///
 /// Provides SSH channel functions

--- a/src/ssh/backend.rs
+++ b/src/ssh/backend.rs
@@ -3,6 +3,8 @@
 
 #[cfg(any(feature = "libssh", feature = "libssh2", feature = "russh"))]
 mod interface;
+#[cfg(any(feature = "libssh", feature = "libssh2", feature = "russh"))]
+mod socket;
 
 #[cfg(feature = "libssh")]
 #[cfg_attr(docsrs, doc(cfg(feature = "libssh")))]

--- a/src/ssh/backend/forward.rs
+++ b/src/ssh/backend/forward.rs
@@ -1,0 +1,969 @@
+use std::io::{Read, Write};
+use std::net::{Shutdown, TcpStream, ToSocketAddrs as _};
+#[cfg(unix)]
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{Receiver, SyncSender, TryRecvError, TrySendError};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use ssh2_config::{RemoteForwardDestination, RemoteForwardListen};
+
+pub(super) const MAX_FORWARD_CONNECTIONS: usize = 64;
+const CONNECTOR_THREADS: usize = 8;
+const CONNECTOR_QUEUE_CAPACITY: usize = 64;
+
+pub(super) fn tcp_remote_forward_endpoint(
+    listen: &RemoteForwardListen,
+) -> Option<(Option<&str>, u16)> {
+    match listen {
+        RemoteForwardListen::Port(port) => Some((Some("localhost"), *port)),
+        RemoteForwardListen::Host { host, port } => {
+            let host = if host.is_empty() || host == "*" {
+                None
+            } else {
+                Some(host.as_str())
+            };
+            Some((host, *port))
+        }
+        RemoteForwardListen::UnixSocket(_) => None,
+    }
+}
+
+pub(super) trait ChannelIo {
+    fn read_channel(&mut self, buffer: &mut [u8]) -> std::io::Result<usize>;
+    fn write_channel(&mut self, buffer: &[u8]) -> std::io::Result<usize>;
+    fn is_eof(&self) -> bool;
+    fn send_eof(&mut self) -> std::io::Result<()>;
+    fn close(&mut self);
+}
+
+enum LocalStream {
+    Tcp(TcpStream),
+    #[cfg(unix)]
+    Unix(UnixStream),
+}
+
+impl LocalStream {
+    fn connect(
+        destination: &RemoteForwardDestination,
+        timeout: Duration,
+        cancellation: &ConnectionCancellation,
+    ) -> std::io::Result<Self> {
+        match destination {
+            RemoteForwardDestination::Host { host, port } => {
+                let addresses = (host.as_str(), *port)
+                    .to_socket_addrs()?
+                    .collect::<Vec<_>>();
+                let mut last_error = None;
+                let deadline = (!timeout.is_zero()).then(|| Instant::now() + timeout);
+                loop {
+                    let mut timed_out = false;
+                    for address in &addresses {
+                        if cancellation.is_cancelled() {
+                            return Err(std::io::Error::new(
+                                std::io::ErrorKind::Interrupted,
+                                "RemoteForward destination connection was cancelled",
+                            ));
+                        }
+                        let attempt_timeout = deadline.map_or(Duration::from_millis(100), |end| {
+                            end.saturating_duration_since(Instant::now())
+                                .min(Duration::from_millis(100))
+                        });
+                        if attempt_timeout.is_zero() {
+                            return Err(last_error.unwrap_or_else(|| {
+                                std::io::Error::new(
+                                    std::io::ErrorKind::TimedOut,
+                                    "RemoteForward destination connect timed out",
+                                )
+                            }));
+                        }
+                        match TcpStream::connect_timeout(address, attempt_timeout) {
+                            Ok(stream) => {
+                                stream.set_nonblocking(true)?;
+                                return Ok(Self::Tcp(stream));
+                            }
+                            Err(err)
+                                if matches!(
+                                    err.kind(),
+                                    std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock
+                                ) =>
+                            {
+                                timed_out = true;
+                                last_error = Some(err);
+                            }
+                            Err(err) => last_error = Some(err),
+                        }
+                    }
+                    if !timed_out || deadline.is_some_and(|end| Instant::now() >= end) {
+                        break;
+                    }
+                }
+                Err(last_error.unwrap_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::AddrNotAvailable,
+                        format!("no address found for RemoteForward destination {host}:{port}"),
+                    )
+                }))
+            }
+            RemoteForwardDestination::UnixSocket(path) => {
+                if cancellation.is_cancelled() {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::Interrupted,
+                        "RemoteForward destination connection was cancelled",
+                    ));
+                }
+                connect_unix(path, timeout, cancellation)
+            }
+        }
+    }
+
+    fn shutdown(&self, how: Shutdown) -> std::io::Result<()> {
+        match self {
+            Self::Tcp(stream) => stream.shutdown(how),
+            #[cfg(unix)]
+            Self::Unix(stream) => stream.shutdown(how),
+        }
+    }
+}
+
+struct PendingConnection {
+    cancelled: Arc<AtomicBool>,
+    receiver: Receiver<std::io::Result<LocalStream>>,
+}
+
+impl Drop for PendingConnection {
+    fn drop(&mut self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+}
+
+struct ConnectionCancellation {
+    connection: Arc<AtomicBool>,
+    session: Arc<AtomicBool>,
+}
+
+impl ConnectionCancellation {
+    fn is_cancelled(&self) -> bool {
+        self.connection.load(Ordering::Acquire) || self.session.load(Ordering::Acquire)
+    }
+}
+
+struct ConnectionJob {
+    cancellation: ConnectionCancellation,
+    destination: RemoteForwardDestination,
+    timeout: Duration,
+    result: SyncSender<std::io::Result<LocalStream>>,
+}
+
+fn connector() -> &'static SyncSender<ConnectionJob> {
+    static CONNECTOR: OnceLock<SyncSender<ConnectionJob>> = OnceLock::new();
+    CONNECTOR.get_or_init(|| {
+        let (sender, receiver) =
+            std::sync::mpsc::sync_channel::<ConnectionJob>(CONNECTOR_QUEUE_CAPACITY);
+        let receiver = Arc::new(Mutex::new(receiver));
+        for _ in 0..CONNECTOR_THREADS {
+            let receiver = Arc::clone(&receiver);
+            std::thread::spawn(move || {
+                loop {
+                    let job = receiver
+                        .lock()
+                        .expect("RemoteForward connector queue poisoned")
+                        .recv();
+                    let Ok(job) = job else {
+                        break;
+                    };
+                    if job.cancellation.is_cancelled() {
+                        continue;
+                    }
+                    let result =
+                        LocalStream::connect(&job.destination, job.timeout, &job.cancellation);
+                    let _ = job.result.send(result);
+                }
+            });
+        }
+        sender
+    })
+}
+
+impl PendingConnection {
+    fn spawn(
+        destination: RemoteForwardDestination,
+        timeout: Duration,
+        session_cancelled: Arc<AtomicBool>,
+    ) -> std::io::Result<Self> {
+        let (result, receiver) = std::sync::mpsc::sync_channel(1);
+        let cancelled = Arc::new(AtomicBool::new(false));
+        connector()
+            .try_send(ConnectionJob {
+                cancellation: ConnectionCancellation {
+                    connection: Arc::clone(&cancelled),
+                    session: session_cancelled,
+                },
+                destination,
+                timeout,
+                result,
+            })
+            .map_err(|err| match err {
+                TrySendError::Full(_) => std::io::Error::new(
+                    std::io::ErrorKind::WouldBlock,
+                    "RemoteForward destination connector queue is full",
+                ),
+                TrySendError::Disconnected(_) => std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "RemoteForward destination connector stopped unexpectedly",
+                ),
+            })?;
+        Ok(Self {
+            cancelled,
+            receiver,
+        })
+    }
+
+    fn poll(&self) -> std::io::Result<Option<LocalStream>> {
+        match self.receiver.try_recv() {
+            Ok(result) => result.map(Some),
+            Err(TryRecvError::Empty) => Ok(None),
+            Err(TryRecvError::Disconnected) => Err(std::io::Error::new(
+                std::io::ErrorKind::ConnectionAborted,
+                "RemoteForward destination connector stopped unexpectedly",
+            )),
+        }
+    }
+}
+
+impl Read for LocalStream {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Tcp(stream) => stream.read(buffer),
+            #[cfg(unix)]
+            Self::Unix(stream) => stream.read(buffer),
+        }
+    }
+}
+
+impl Write for LocalStream {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Tcp(stream) => stream.write(buffer),
+            #[cfg(unix)]
+            Self::Unix(stream) => stream.write(buffer),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn connect_unix(
+    path: &Path,
+    _timeout: Duration,
+    _cancellation: &ConnectionCancellation,
+) -> std::io::Result<LocalStream> {
+    let stream = UnixStream::connect(path)?;
+    stream.set_nonblocking(true)?;
+    Ok(LocalStream::Unix(stream))
+}
+
+#[cfg(not(unix))]
+fn connect_unix(
+    path: &Path,
+    _timeout: Duration,
+    _cancellation: &ConnectionCancellation,
+) -> std::io::Result<LocalStream> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        format!(
+            "Unix socket RemoteForward destination {} is unavailable on this platform",
+            path.display()
+        ),
+    ))
+}
+
+pub(super) struct ForwardConnection<C: ChannelIo> {
+    channel: C,
+    state: ConnectionState,
+}
+
+enum ConnectionState {
+    Connecting(PendingConnection),
+    Socks(SocksHandshake),
+    Relay(RelayState),
+}
+
+struct SocksHandshake {
+    phase: SocksPhase,
+    input: Vec<u8>,
+    output: Vec<u8>,
+    destination: Option<LocalStream>,
+    pending_connection: Option<PendingConnection>,
+    pending_version: Option<u8>,
+    failed: bool,
+    connect_timeout: Duration,
+    session_cancelled: Arc<AtomicBool>,
+}
+
+enum SocksPhase {
+    Greeting,
+    Socks5Request,
+    Connecting,
+    Reply,
+}
+
+struct RelayState {
+    destination: LocalStream,
+    to_destination: Vec<u8>,
+    to_remote: Vec<u8>,
+    remote_eof: bool,
+    local_eof: bool,
+    local_write_shutdown: bool,
+    remote_eof_sent: bool,
+}
+
+impl<C> ForwardConnection<C>
+where
+    C: ChannelIo,
+{
+    pub(super) fn fixed(
+        channel: C,
+        destination: &RemoteForwardDestination,
+        timeout: Duration,
+        session_cancelled: Arc<AtomicBool>,
+    ) -> std::io::Result<Self> {
+        Ok(Self {
+            channel,
+            state: ConnectionState::Connecting(PendingConnection::spawn(
+                destination.clone(),
+                timeout,
+                session_cancelled,
+            )?),
+        })
+    }
+
+    pub(super) fn dynamic(
+        channel: C,
+        connect_timeout: Duration,
+        session_cancelled: Arc<AtomicBool>,
+    ) -> Self {
+        Self {
+            channel,
+            state: ConnectionState::Socks(SocksHandshake {
+                phase: SocksPhase::Greeting,
+                input: Vec::new(),
+                output: Vec::new(),
+                destination: None,
+                pending_connection: None,
+                pending_version: None,
+                failed: false,
+                connect_timeout,
+                session_cancelled,
+            }),
+        }
+    }
+
+    pub(super) fn pump(&mut self) -> std::io::Result<(bool, bool)> {
+        let transition = match &mut self.state {
+            ConnectionState::Connecting(connection) => match connection.poll()? {
+                Some(destination) => {
+                    self.state = ConnectionState::Relay(RelayState::new(destination));
+                    return Ok((true, true));
+                }
+                None => return Ok((true, false)),
+            },
+            ConnectionState::Socks(handshake) => handshake.pump(&mut self.channel)?,
+            ConnectionState::Relay(relay) => return relay.pump(&mut self.channel),
+        };
+        match transition {
+            SocksTransition::Pending(progressed) => Ok((true, progressed)),
+            SocksTransition::Connected(destination, initial_data) => {
+                let mut relay = RelayState::new(destination);
+                relay.to_destination = initial_data;
+                self.state = ConnectionState::Relay(relay);
+                Ok((true, true))
+            }
+            SocksTransition::Failed => Ok((false, true)),
+        }
+    }
+}
+
+impl<C> Drop for ForwardConnection<C>
+where
+    C: ChannelIo,
+{
+    fn drop(&mut self) {
+        self.channel.close();
+    }
+}
+
+impl RelayState {
+    fn new(destination: LocalStream) -> Self {
+        Self {
+            destination,
+            to_destination: Vec::new(),
+            to_remote: Vec::new(),
+            remote_eof: false,
+            local_eof: false,
+            local_write_shutdown: false,
+            remote_eof_sent: false,
+        }
+    }
+
+    fn pump<C>(&mut self, channel: &mut C) -> std::io::Result<(bool, bool)>
+    where
+        C: ChannelIo,
+    {
+        let mut progressed = false;
+        let mut buffer = [0u8; 8192];
+
+        if !self.remote_eof && self.to_destination.len() < 64 * 1024 {
+            match channel.read_channel(&mut buffer) {
+                Ok(0) => self.remote_eof = channel.is_eof(),
+                Ok(bytes) => {
+                    self.to_destination.extend_from_slice(&buffer[..bytes]);
+                    progressed = true;
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                    self.remote_eof = channel.is_eof();
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        if !self.to_destination.is_empty() {
+            match self.destination.write(&self.to_destination) {
+                Ok(0) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::WriteZero,
+                        "RemoteForward destination closed while writing",
+                    ));
+                }
+                Ok(bytes) => {
+                    self.to_destination.drain(..bytes);
+                    progressed = true;
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(err) => return Err(err),
+            }
+        }
+        if self.remote_eof && self.to_destination.is_empty() && !self.local_write_shutdown {
+            self.destination.shutdown(Shutdown::Write)?;
+            self.local_write_shutdown = true;
+            progressed = true;
+        }
+
+        if !self.local_eof && self.to_remote.len() < 64 * 1024 {
+            match self.destination.read(&mut buffer) {
+                Ok(0) => self.local_eof = true,
+                Ok(bytes) => {
+                    self.to_remote.extend_from_slice(&buffer[..bytes]);
+                    progressed = true;
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(err) => return Err(err),
+            }
+        }
+        if !self.to_remote.is_empty() {
+            match channel.write_channel(&self.to_remote) {
+                Ok(0) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::WriteZero,
+                        "RemoteForward channel closed while writing",
+                    ));
+                }
+                Ok(bytes) => {
+                    self.to_remote.drain(..bytes);
+                    progressed = true;
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(err) => return Err(err),
+            }
+        }
+        if self.local_eof && self.to_remote.is_empty() && !self.remote_eof_sent {
+            match channel.send_eof() {
+                Ok(()) => {
+                    self.remote_eof_sent = true;
+                    progressed = true;
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(err) => return Err(err),
+            }
+        }
+
+        let keep = !(self.remote_eof
+            && self.local_write_shutdown
+            && self.local_eof
+            && self.to_remote.is_empty()
+            && self.remote_eof_sent);
+        Ok((keep, progressed))
+    }
+}
+
+enum SocksTransition {
+    Pending(bool),
+    Connected(LocalStream, Vec<u8>),
+    Failed,
+}
+
+impl SocksHandshake {
+    fn pump<C>(&mut self, channel: &mut C) -> std::io::Result<SocksTransition>
+    where
+        C: ChannelIo,
+    {
+        let mut progressed = false;
+        if !self.output.is_empty() {
+            match channel.write_channel(&self.output) {
+                Ok(0) => return Ok(SocksTransition::Failed),
+                Ok(bytes) => {
+                    self.output.drain(..bytes);
+                    progressed = true;
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(err) => return Err(err),
+            }
+        }
+        if matches!(self.phase, SocksPhase::Reply) && self.output.is_empty() {
+            if self.failed {
+                return Ok(SocksTransition::Failed);
+            }
+            return Ok(SocksTransition::Connected(
+                self.destination
+                    .take()
+                    .expect("successful SOCKS reply has a destination"),
+                std::mem::take(&mut self.input),
+            ));
+        }
+
+        if matches!(self.phase, SocksPhase::Connecting) {
+            let Some(connection) = &self.pending_connection else {
+                unreachable!("connecting SOCKS handshake has a pending destination");
+            };
+            let result = match connection.poll() {
+                Ok(Some(stream)) => Ok(stream),
+                Ok(None) => return Ok(SocksTransition::Pending(progressed)),
+                Err(err) => Err(err),
+            };
+            let version = self
+                .pending_version
+                .take()
+                .expect("connecting SOCKS handshake has a protocol version");
+            self.pending_connection = None;
+            match result {
+                Ok(stream) => {
+                    self.destination = Some(stream);
+                    if version == 4 {
+                        self.output.extend_from_slice(&[0, 90, 0, 0, 0, 0, 0, 0]);
+                    } else {
+                        self.output
+                            .extend_from_slice(&[5, 0, 0, 1, 0, 0, 0, 0, 0, 0]);
+                    }
+                }
+                Err(err) => {
+                    warn!("Dynamic RemoteForward destination failed: {err}");
+                    self.failed = true;
+                    if version == 4 {
+                        self.output.extend_from_slice(&[0, 91, 0, 0, 0, 0, 0, 0]);
+                    } else {
+                        self.output
+                            .extend_from_slice(&[5, 1, 0, 1, 0, 0, 0, 0, 0, 0]);
+                    }
+                }
+            }
+            self.phase = SocksPhase::Reply;
+            return Ok(SocksTransition::Pending(true));
+        }
+
+        let mut buffer = [0u8; 1024];
+        match channel.read_channel(&mut buffer) {
+            Ok(0) if channel.is_eof() => return Ok(SocksTransition::Failed),
+            Ok(0) => {}
+            Ok(bytes) => {
+                if self.input.len() + bytes > 4096 {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "SOCKS handshake exceeds 4096 bytes",
+                    ));
+                }
+                self.input.extend_from_slice(&buffer[..bytes]);
+                progressed = true;
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {}
+            Err(err) => return Err(err),
+        }
+
+        match self.phase {
+            SocksPhase::Greeting => self.parse_greeting()?,
+            SocksPhase::Socks5Request => self.parse_socks5_request()?,
+            SocksPhase::Connecting | SocksPhase::Reply => {}
+        }
+        Ok(SocksTransition::Pending(progressed))
+    }
+
+    fn parse_greeting(&mut self) -> std::io::Result<()> {
+        let Some(version) = self.input.first().copied() else {
+            return Ok(());
+        };
+        match version {
+            4 => match parse_socks4_request(&self.input) {
+                Ok(Some((consumed, host, port))) => {
+                    self.input.drain(..consumed);
+                    self.connect(host, port, 4);
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    warn!("Dynamic RemoteForward rejected SOCKS4 request: {err}");
+                    self.output.extend_from_slice(&[0, 91, 0, 0, 0, 0, 0, 0]);
+                    self.failed = true;
+                    self.phase = SocksPhase::Reply;
+                }
+            },
+            5 => {
+                let Some(method_count) = self.input.get(1).copied().map(usize::from) else {
+                    return Ok(());
+                };
+                let length = 2 + method_count;
+                if self.input.len() < length {
+                    return Ok(());
+                }
+                let supports_no_auth = self.input[2..length].contains(&0);
+                self.input.drain(..length);
+                if supports_no_auth {
+                    self.output.extend_from_slice(&[5, 0]);
+                    self.phase = SocksPhase::Socks5Request;
+                } else {
+                    self.output.extend_from_slice(&[5, 0xff]);
+                    self.failed = true;
+                    self.phase = SocksPhase::Reply;
+                }
+            }
+            _ => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("unsupported SOCKS version {version}"),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn parse_socks5_request(&mut self) -> std::io::Result<()> {
+        match parse_socks5_request(&self.input) {
+            Ok(Some((consumed, host, port))) => {
+                self.input.drain(..consumed);
+                self.connect(host, port, 5);
+            }
+            Ok(None) => {}
+            Err(err) => {
+                warn!("Dynamic RemoteForward rejected SOCKS5 request: {err}");
+                self.output
+                    .extend_from_slice(&[5, 7, 0, 1, 0, 0, 0, 0, 0, 0]);
+                self.failed = true;
+                self.phase = SocksPhase::Reply;
+            }
+        }
+        Ok(())
+    }
+
+    fn connect(&mut self, host: String, port: u16, version: u8) {
+        let destination = RemoteForwardDestination::Host { host, port };
+        match PendingConnection::spawn(
+            destination,
+            self.connect_timeout,
+            Arc::clone(&self.session_cancelled),
+        ) {
+            Ok(connection) => {
+                self.pending_connection = Some(connection);
+                self.pending_version = Some(version);
+                self.phase = SocksPhase::Connecting;
+            }
+            Err(err) => {
+                warn!("Dynamic RemoteForward destination could not be queued: {err}");
+                self.failed = true;
+                if version == 4 {
+                    self.output.extend_from_slice(&[0, 91, 0, 0, 0, 0, 0, 0]);
+                } else {
+                    self.output
+                        .extend_from_slice(&[5, 1, 0, 1, 0, 0, 0, 0, 0, 0]);
+                }
+                self.phase = SocksPhase::Reply;
+            }
+        }
+    }
+}
+
+fn parse_socks4_request(input: &[u8]) -> std::io::Result<Option<(usize, String, u16)>> {
+    if input.len() < 9 {
+        return Ok(None);
+    }
+    if input[1] != 1 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "SOCKS4 supports CONNECT only",
+        ));
+    }
+    let Some(user_end) = input[8..].iter().position(|byte| *byte == 0) else {
+        return Ok(None);
+    };
+    let mut consumed = 8 + user_end + 1;
+    let address = [input[4], input[5], input[6], input[7]];
+    let host = if address[..3] == [0, 0, 0] && address[3] != 0 {
+        let Some(domain_end) = input[consumed..].iter().position(|byte| *byte == 0) else {
+            return Ok(None);
+        };
+        let domain = String::from_utf8(input[consumed..consumed + domain_end].to_vec())
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err.to_string()))?;
+        consumed += domain_end + 1;
+        domain
+    } else {
+        std::net::Ipv4Addr::from(address).to_string()
+    };
+    Ok(Some((
+        consumed,
+        host,
+        u16::from_be_bytes([input[2], input[3]]),
+    )))
+}
+
+fn parse_socks5_request(input: &[u8]) -> std::io::Result<Option<(usize, String, u16)>> {
+    if input.len() < 4 {
+        return Ok(None);
+    }
+    if input[0] != 5 || input[1] != 1 || input[2] != 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "SOCKS5 supports CONNECT only",
+        ));
+    }
+    let (address_end, host) = match input[3] {
+        1 => {
+            if input.len() < 10 {
+                return Ok(None);
+            }
+            (
+                8,
+                std::net::Ipv4Addr::new(input[4], input[5], input[6], input[7]).to_string(),
+            )
+        }
+        3 => {
+            let Some(length) = input.get(4).copied().map(usize::from) else {
+                return Ok(None);
+            };
+            let address_end = 5 + length;
+            if input.len() < address_end + 2 {
+                return Ok(None);
+            }
+            let domain = String::from_utf8(input[5..address_end].to_vec()).map_err(|err| {
+                std::io::Error::new(std::io::ErrorKind::InvalidData, err.to_string())
+            })?;
+            (address_end, domain)
+        }
+        4 => {
+            if input.len() < 22 {
+                return Ok(None);
+            }
+            let mut address = [0u8; 16];
+            address.copy_from_slice(&input[4..20]);
+            (20, std::net::Ipv6Addr::from(address).to_string())
+        }
+        address_type => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                format!("unsupported SOCKS5 address type {address_type}"),
+            ));
+        }
+    };
+    let port_end = address_end + 2;
+    if input.len() < port_end {
+        return Ok(None);
+    }
+    Ok(Some((
+        port_end,
+        host,
+        u16::from_be_bytes([input[address_end], input[address_end + 1]]),
+    )))
+}
+
+pub(super) struct ForwardWorker {
+    cancelled: Arc<AtomicBool>,
+    worker: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl ForwardWorker {
+    pub(super) fn new(cancelled: Arc<AtomicBool>, worker: JoinHandle<()>) -> Self {
+        Self {
+            cancelled,
+            worker: Mutex::new(Some(worker)),
+        }
+    }
+
+    pub(super) fn stop(&self) {
+        self.cancelled.store(true, Ordering::Release);
+        let worker = self
+            .worker
+            .lock()
+            .expect("RemoteForward worker lock poisoned")
+            .take();
+        if let Some(worker) = worker
+            && worker.join().is_err()
+        {
+            warn!("RemoteForward worker panicked");
+        }
+    }
+}
+
+impl Drop for ForwardWorker {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use ssh2_config::RemoteForwardListen;
+
+    use super::{
+        ConnectionCancellation, LocalStream, PendingConnection, RemoteForwardDestination,
+        parse_socks4_request, parse_socks5_request, tcp_remote_forward_endpoint,
+    };
+
+    #[test]
+    fn should_cancel_pending_destination_without_configured_timeout() {
+        let session_cancelled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let connection = PendingConnection::spawn(
+            RemoteForwardDestination::Host {
+                host: "203.0.113.1".to_string(),
+                port: 9,
+            },
+            Duration::ZERO,
+            std::sync::Arc::clone(&session_cancelled),
+        )
+        .expect("failed to queue destination connection");
+        session_cancelled.store(true, std::sync::atomic::Ordering::Release);
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            match connection.poll() {
+                Ok(None) if std::time::Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(_) => break,
+                Ok(Some(_)) => panic!("cancelled destination unexpectedly connected"),
+                Ok(None) => panic!("cancelled destination did not stop promptly"),
+            }
+        }
+    }
+
+    #[test]
+    fn should_connect_destination_without_timeout() {
+        let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+            .expect("failed to bind destination listener");
+        let port = listener
+            .local_addr()
+            .expect("failed to inspect destination listener")
+            .port();
+        let destination = RemoteForwardDestination::Host {
+            host: "127.0.0.1".to_string(),
+            port,
+        };
+        let _stream = LocalStream::connect(
+            &destination,
+            Duration::ZERO,
+            &ConnectionCancellation {
+                connection: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                session: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            },
+        )
+        .expect("zero timeout should allow a blocking destination connection");
+        listener
+            .accept()
+            .expect("failed to accept destination connection");
+    }
+
+    #[test]
+    fn should_normalize_remote_forward_bind_addresses() {
+        assert_eq!(
+            tcp_remote_forward_endpoint(&RemoteForwardListen::Port(8080)),
+            Some((Some("localhost"), 8080))
+        );
+        for host in ["", "*"] {
+            assert_eq!(
+                tcp_remote_forward_endpoint(&RemoteForwardListen::Host {
+                    host: host.to_string(),
+                    port: 8080,
+                }),
+                Some((None, 8080))
+            );
+        }
+        assert_eq!(
+            tcp_remote_forward_endpoint(&RemoteForwardListen::Host {
+                host: "127.0.0.1".to_string(),
+                port: 8080,
+            }),
+            Some((Some("127.0.0.1"), 8080))
+        );
+    }
+
+    #[test]
+    fn should_parse_socks4_and_socks4a_connect_requests() {
+        assert_eq!(
+            parse_socks4_request(&[4, 1, 0, 80, 127, 0, 0, 1, 0])
+                .expect("failed to parse SOCKS4")
+                .expect("SOCKS4 request is incomplete"),
+            (9, "127.0.0.1".to_string(), 80)
+        );
+        let request = [
+            4, 1, 0, 22, 0, 0, 0, 1, 0, b'e', b'x', b'a', b'm', b'p', b'l', b'e', 0,
+        ];
+        assert_eq!(
+            parse_socks4_request(&request)
+                .expect("failed to parse SOCKS4a")
+                .expect("SOCKS4a request is incomplete"),
+            (request.len(), "example".to_string(), 22)
+        );
+    }
+
+    #[test]
+    fn should_parse_socks5_connect_address_variants() {
+        assert_eq!(
+            parse_socks5_request(&[5, 1, 0, 1, 127, 0, 0, 1, 0, 80])
+                .expect("failed to parse SOCKS5 IPv4")
+                .expect("SOCKS5 IPv4 request is incomplete"),
+            (10, "127.0.0.1".to_string(), 80)
+        );
+        let domain = [
+            5, 1, 0, 3, 7, b'e', b'x', b'a', b'm', b'p', b'l', b'e', 0, 22,
+        ];
+        assert_eq!(
+            parse_socks5_request(&domain)
+                .expect("failed to parse SOCKS5 domain")
+                .expect("SOCKS5 domain request is incomplete"),
+            (domain.len(), "example".to_string(), 22)
+        );
+        let mut ipv6 = vec![5, 1, 0, 4];
+        ipv6.extend_from_slice(&std::net::Ipv6Addr::LOCALHOST.octets());
+        ipv6.extend_from_slice(&443_u16.to_be_bytes());
+        assert_eq!(
+            parse_socks5_request(&ipv6)
+                .expect("failed to parse SOCKS5 IPv6")
+                .expect("SOCKS5 IPv6 request is incomplete"),
+            (ipv6.len(), "::1".to_string(), 443)
+        );
+    }
+
+    #[test]
+    fn should_wait_for_complete_socks_requests() {
+        assert!(
+            parse_socks4_request(&[4, 1, 0, 80, 127, 0, 0, 1])
+                .expect("failed to inspect partial SOCKS4")
+                .is_none()
+        );
+        assert!(
+            parse_socks5_request(&[5, 1, 0, 3, 7, b'e'])
+                .expect("failed to inspect partial SOCKS5")
+                .is_none()
+        );
+    }
+}

--- a/src/ssh/backend/forward.rs
+++ b/src/ssh/backend/forward.rs
@@ -11,7 +11,6 @@ use std::time::{Duration, Instant};
 
 use ssh2_config::{RemoteForwardDestination, RemoteForwardListen};
 
-pub(super) const MAX_FORWARD_CONNECTIONS: usize = 64;
 const CONNECTOR_THREADS: usize = 8;
 const CONNECTOR_QUEUE_CAPACITY: usize = 64;
 

--- a/src/ssh/backend/interface.rs
+++ b/src/ssh/backend/interface.rs
@@ -1,0 +1,44 @@
+use std::io;
+use std::net::{IpAddr, SocketAddr, SocketAddrV4, SocketAddrV6};
+
+pub(super) fn addresses(name: &str) -> io::Result<Vec<SocketAddr>> {
+    let mut interfaces = if_addrs::get_if_addrs()?
+        .into_iter()
+        .filter(|interface| interface.name == name)
+        .collect::<Vec<_>>();
+    interfaces.sort_by_key(|interface| interface.is_loopback() || interface.is_link_local());
+
+    let mut addresses = Vec::with_capacity(interfaces.len());
+    for interface in interfaces {
+        let address = match interface.ip() {
+            IpAddr::V4(address) => SocketAddr::V4(SocketAddrV4::new(address, 0)),
+            IpAddr::V6(address) => SocketAddr::V6(SocketAddrV6::new(
+                address,
+                0,
+                0,
+                interface.index.unwrap_or(0),
+            )),
+        };
+        if !addresses.contains(&address) {
+            addresses.push(address);
+        }
+    }
+
+    if addresses.is_empty() {
+        Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("BindInterface {name} does not exist or has no IP address"),
+        ))
+    } else {
+        Ok(addresses)
+    }
+}
+
+#[cfg(feature = "libssh")]
+pub(super) fn host(address: &SocketAddr) -> String {
+    match address {
+        SocketAddr::V4(address) => address.ip().to_string(),
+        SocketAddr::V6(address) if address.scope_id() == 0 => address.ip().to_string(),
+        SocketAddr::V6(address) => format!("{}%{}", address.ip(), address.scope_id()),
+    }
+}

--- a/src/ssh/backend/keepalive.rs
+++ b/src/ssh/backend/keepalive.rs
@@ -1,0 +1,162 @@
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+/// Runs a backend keepalive operation at a fixed interval until stopped or
+/// the operation reports that the connection is no longer usable.
+pub(super) struct ServerKeepalive {
+    state: Arc<(Mutex<WorkerState>, Condvar)>,
+    shutdown: Mutex<Option<Box<dyn FnOnce() + Send>>>,
+    worker: Mutex<Option<JoinHandle<()>>>,
+}
+
+struct WorkerState {
+    active: bool,
+    cancelled: bool,
+}
+
+impl ServerKeepalive {
+    pub(super) fn spawn(
+        interval: Duration,
+        shutdown: impl FnOnce() + Send + 'static,
+        mut send: impl FnMut() -> bool + Send + 'static,
+    ) -> Option<Self> {
+        if interval.is_zero() {
+            return None;
+        }
+
+        let state = Arc::new((
+            Mutex::new(WorkerState {
+                active: false,
+                cancelled: false,
+            }),
+            Condvar::new(),
+        ));
+        let worker_state = Arc::clone(&state);
+        let worker = std::thread::spawn(move || {
+            let (state, wake) = &*worker_state;
+            let mut state = state.lock().expect("server keepalive state was poisoned");
+            loop {
+                let result = wake
+                    .wait_timeout_while(state, interval, |state| !state.cancelled)
+                    .expect("server keepalive state was poisoned");
+                state = result.0;
+                if state.cancelled {
+                    break;
+                }
+                state.active = true;
+                drop(state);
+                let keep_running = send();
+                state = worker_state
+                    .0
+                    .lock()
+                    .expect("server keepalive state was poisoned");
+                state.active = false;
+                wake.notify_all();
+                if !keep_running {
+                    break;
+                }
+            }
+        });
+
+        Some(Self {
+            state,
+            shutdown: Mutex::new(Some(Box::new(shutdown))),
+            worker: Mutex::new(Some(worker)),
+        })
+    }
+
+    /// Stops the worker, returning whether its transport had to be interrupted.
+    pub(super) fn stop(&self) -> bool {
+        let (state, wake) = &*self.state;
+        let mut state = state.lock().expect("server keepalive state was poisoned");
+        state.cancelled = true;
+        wake.notify_all();
+        if state.active {
+            state = wake
+                .wait_timeout_while(state, Duration::from_millis(100), |state| state.active)
+                .expect("server keepalive state was poisoned")
+                .0;
+        }
+        let interrupted = state.active;
+        drop(state);
+        let shutdown = self
+            .shutdown
+            .lock()
+            .expect("server keepalive shutdown was poisoned")
+            .take();
+        if interrupted && let Some(shutdown) = shutdown {
+            shutdown();
+        }
+        if let Some(worker) = self
+            .worker
+            .lock()
+            .expect("server keepalive worker was poisoned")
+            .take()
+        {
+            let _ = worker.join();
+        }
+        interrupted
+    }
+}
+
+impl Drop for ServerKeepalive {
+    fn drop(&mut self) {
+        let _ = self.stop();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc;
+
+    use super::*;
+
+    #[test]
+    fn should_run_and_stop_server_keepalive() {
+        let (sender, receiver) = mpsc::channel();
+        let (shutdown_sender, shutdown_receiver) = mpsc::channel();
+        let keepalive = ServerKeepalive::spawn(
+            Duration::from_millis(1),
+            move || {
+                shutdown_sender
+                    .send(())
+                    .expect("failed to report forced shutdown");
+            },
+            move || sender.send(()).is_ok(),
+        )
+        .expect("keepalive should be enabled");
+
+        receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("keepalive did not run");
+        assert!(!keepalive.stop());
+        assert!(shutdown_receiver.try_recv().is_err());
+        assert!(ServerKeepalive::spawn(Duration::ZERO, || {}, || true).is_none());
+    }
+
+    #[test]
+    fn should_interrupt_active_keepalive_when_stopped() {
+        let (entered_sender, entered_receiver) = mpsc::channel();
+        let (release_sender, release_receiver) = mpsc::channel::<()>();
+        let keepalive = ServerKeepalive::spawn(
+            Duration::from_millis(1),
+            move || {
+                let _ = release_sender.send(());
+            },
+            move || {
+                entered_sender
+                    .send(())
+                    .expect("failed to report active keepalive");
+                let _ = release_receiver.recv();
+                false
+            },
+        )
+        .expect("keepalive should be enabled");
+        entered_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("keepalive did not run");
+
+        assert!(keepalive.stop());
+    }
+}

--- a/src/ssh/backend/libssh.rs
+++ b/src/ssh/backend/libssh.rs
@@ -9,7 +9,7 @@ use remotefs::fs::stream::{ReadAndSeek, WriteAndSeek};
 use remotefs::fs::{FileType, Metadata, ReadStream, UnixPex, WriteStream};
 use remotefs::{File, RemoteError, RemoteErrorType, RemoteResult};
 
-use super::{SshSession, interface};
+use super::{SshSession, interface, socket};
 use crate::SshOpts;
 use crate::ssh::backend::Sftp;
 use crate::ssh::config::Config;
@@ -228,6 +228,8 @@ impl SshSession for LibSshSession {
             error!("SSH handshake failed: {err}");
             return Err(RemoteError::new_ex(RemoteErrorType::ProtocolError, err));
         }
+        socket::set_keepalive(&session, ssh_config.params.tcp_keep_alive.unwrap_or(true))
+            .map_err(|e| RemoteError::new_ex(RemoteErrorType::ConnectionError, e))?;
 
         // try to authenticate userauth_none
         authenticate(&mut session, opts)?;
@@ -1161,6 +1163,42 @@ mod tests {
             .password("password");
         let session = LibSshSession::connect(&opts)
             .expect("BindAddress should take precedence over BindInterface");
+        session.disconnect().expect("failed to disconnect");
+    }
+
+    #[test]
+    fn should_apply_configured_tcp_keep_alive() {
+        let container = OpensshServer::start();
+        let port = container.port();
+        for (configured, expected) in [("yes", true), ("no", false)] {
+            let mut config_file = NamedTempFile::new().expect("failed to create SSH config");
+            writeln!(
+                config_file,
+                "Host keepalive\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    TCPKeepAlive {configured}"
+            )
+            .expect("failed to write SSH config");
+            let opts = SshOpts::new("keepalive")
+                .config_file(config_file.path(), ParseRule::STRICT)
+                .password("password");
+            let session = LibSshSession::connect(&opts).expect("failed to connect");
+
+            assert_eq!(
+                crate::ssh::backend::socket::keepalive(&session.session)
+                    .expect("failed to read SO_KEEPALIVE"),
+                expected
+            );
+            session.disconnect().expect("failed to disconnect");
+        }
+
+        let opts = SshOpts::new("127.0.0.1")
+            .port(port)
+            .username("sftp")
+            .password("password");
+        let session = LibSshSession::connect(&opts).expect("failed to connect");
+        assert!(
+            crate::ssh::backend::socket::keepalive(&session.session)
+                .expect("failed to read default SO_KEEPALIVE")
+        );
         session.disconnect().expect("failed to disconnect");
     }
 }

--- a/src/ssh/backend/libssh.rs
+++ b/src/ssh/backend/libssh.rs
@@ -1,5 +1,9 @@
 use std::io::{Cursor, Read, Seek, Write};
+#[cfg(unix)]
+use std::net::Shutdown;
 use std::net::ToSocketAddrs as _;
+#[cfg(unix)]
+use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::str::FromStr as _;
 use std::time::{Duration, Instant, UNIX_EPOCH};
@@ -19,6 +23,7 @@ use crate::ssh::config::Config;
 /// See <https://docs.rs/libssh-rs/0.3.6/libssh_rs/struct.Session.html>
 pub struct LibSshSession {
     session: libssh_rs::Session,
+    forward_agent: bool,
 }
 
 /// A wrapper around [`libssh_rs::Sftp`] to provide a SFTP client for [`LibSshSession`]
@@ -234,7 +239,13 @@ impl SshSession for LibSshSession {
         // try to authenticate userauth_none
         authenticate(&mut session, opts)?;
 
-        Ok(Self { session })
+        let forward_agent = ssh_config.params.forward_agent.unwrap_or(false);
+        session.enable_accept_agent_forward(forward_agent);
+
+        Ok(Self {
+            session,
+            forward_agent,
+        })
     }
 
     fn authenticated(&self) -> RemoteResult<bool> {
@@ -260,7 +271,11 @@ impl SshSession for LibSshSession {
     where
         S: AsRef<str>,
     {
-        let output = perform_shell_cmd(&mut self.session, format!("{}; echo $?", cmd.as_ref()))?;
+        let output = perform_shell_cmd(
+            &mut self.session,
+            format!("{}; echo $?", cmd.as_ref()),
+            self.forward_agent,
+        )?;
         if let Some(index) = output.trim().rfind('\n') {
             trace!("Read from stdout: '{output}'");
             let actual_output = (output[0..index + 1]).to_string();
@@ -932,6 +947,7 @@ fn key_storage_auth(
 fn perform_shell_cmd<S: AsRef<str>>(
     session: &mut libssh_rs::Session,
     cmd: S,
+    forward_agent: bool,
 ) -> RemoteResult<String> {
     // Create channel
     trace!("Running command: {}", cmd.as_ref());
@@ -952,6 +968,14 @@ fn perform_shell_cmd<S: AsRef<str>>(
             format!("Could not open session: {err}"),
         )
     })?;
+    if forward_agent {
+        channel.request_auth_agent().map_err(|err| {
+            RemoteError::new_ex(
+                RemoteErrorType::ProtocolError,
+                format!("Could not request SSH agent forwarding: {err}"),
+            )
+        })?;
+    }
 
     // escape single quotes in command
     let cmd = cmd.as_ref().replace('\'', r#"'\''"#); // close, escape, and reopen
@@ -974,20 +998,234 @@ fn perform_shell_cmd<S: AsRef<str>>(
         )
     })?;
 
-    // Read output
-    let mut output: String = String::new();
-    match channel.stdout().read_to_string(&mut output) {
-        Ok(_) => {
-            // Wait close
-            let res = channel.get_exit_status();
-            trace!("Command output (res: {res:?}): {output}");
-            Ok(output)
-        }
-        Err(err) => Err(RemoteError::new_ex(
-            RemoteErrorType::ProtocolError,
-            format!("Could not read output: {err}"),
-        )),
+    let output = if forward_agent {
+        read_command_with_agent_forwarding(session, &channel)?
+    } else {
+        let mut output = String::new();
+        channel
+            .stdout()
+            .read_to_string(&mut output)
+            .map_err(|err| {
+                RemoteError::new_ex(
+                    RemoteErrorType::ProtocolError,
+                    format!("Could not read output: {err}"),
+                )
+            })?;
+        output
+    };
+
+    let res = channel.get_exit_status();
+    trace!("Command output (res: {res:?}): {output}");
+    Ok(output)
+}
+
+#[cfg(unix)]
+struct AgentForwardRelay {
+    channel: libssh_rs::Channel,
+    socket: UnixStream,
+    to_agent: Vec<u8>,
+    to_remote: Vec<u8>,
+    remote_eof: bool,
+    local_eof: bool,
+    agent_write_shutdown: bool,
+    sent_eof: bool,
+}
+
+#[cfg(unix)]
+impl AgentForwardRelay {
+    fn connect(channel: libssh_rs::Channel) -> std::io::Result<Self> {
+        let socket_path = std::env::var_os("SSH_AUTH_SOCK").ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "SSH_AUTH_SOCK is not configured",
+            )
+        })?;
+        let socket = UnixStream::connect(socket_path)?;
+        socket.set_nonblocking(true)?;
+        Ok(Self {
+            channel,
+            socket,
+            to_agent: Vec::new(),
+            to_remote: Vec::new(),
+            remote_eof: false,
+            local_eof: false,
+            agent_write_shutdown: false,
+            sent_eof: false,
+        })
     }
+
+    fn pump(&mut self) -> Result<(bool, bool), String> {
+        let mut progressed = false;
+        let mut buffer = [0u8; 8192];
+
+        if !self.remote_eof && self.to_agent.len() < 64 * 1024 {
+            match self
+                .channel
+                .read_timeout(&mut buffer, false, Some(Duration::ZERO))
+            {
+                Ok(0) => self.remote_eof = self.channel.is_eof(),
+                Ok(bytes) => {
+                    self.to_agent.extend_from_slice(&buffer[..bytes]);
+                    progressed = true;
+                }
+                Err(libssh_rs::Error::TryAgain) => {
+                    self.remote_eof = self.channel.is_eof();
+                }
+                Err(err) => return Err(format!("Could not read forwarded agent request: {err}")),
+            }
+        }
+
+        if !self.to_agent.is_empty() {
+            match self.socket.write(&self.to_agent) {
+                Ok(0) => return Err("Local SSH agent closed while writing".to_string()),
+                Ok(bytes) => {
+                    self.to_agent.drain(..bytes);
+                    progressed = true;
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(err) => return Err(format!("Could not write to local SSH agent: {err}")),
+            }
+        }
+
+        if self.remote_eof && self.to_agent.is_empty() && !self.agent_write_shutdown {
+            self.socket
+                .shutdown(Shutdown::Write)
+                .map_err(|err| format!("Could not half-close local SSH agent socket: {err}"))?;
+            self.agent_write_shutdown = true;
+            progressed = true;
+        }
+
+        if !self.local_eof && self.to_remote.len() < 64 * 1024 {
+            match self.socket.read(&mut buffer) {
+                Ok(0) => self.local_eof = true,
+                Ok(bytes) => {
+                    self.to_remote.extend_from_slice(&buffer[..bytes]);
+                    progressed = true;
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(err) => return Err(format!("Could not read from local SSH agent: {err}")),
+            }
+        }
+
+        if !self.to_remote.is_empty() {
+            match self.channel.stdin().write(&self.to_remote) {
+                Ok(0) => return Err("Forwarded SSH agent channel closed while writing".to_string()),
+                Ok(bytes) => {
+                    self.to_remote.drain(..bytes);
+                    progressed = true;
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(err) => {
+                    return Err(format!("Could not write forwarded agent response: {err}"));
+                }
+            }
+        }
+
+        if self.local_eof && self.to_remote.is_empty() && !self.sent_eof {
+            match self.channel.send_eof() {
+                Ok(()) => {
+                    self.sent_eof = true;
+                    progressed = true;
+                }
+                Err(libssh_rs::Error::TryAgain) => {}
+                Err(err) => return Err(format!("Could not close forwarded agent channel: {err}")),
+            }
+        }
+
+        let keep = !(self.remote_eof
+            && self.to_agent.is_empty()
+            && self.local_eof
+            && self.to_remote.is_empty()
+            && self.sent_eof);
+        if !keep {
+            let _ = self.socket.shutdown(Shutdown::Both);
+        }
+        Ok((keep, progressed))
+    }
+}
+
+#[cfg(unix)]
+fn read_command_with_agent_forwarding(
+    session: &libssh_rs::Session,
+    channel: &libssh_rs::Channel,
+) -> RemoteResult<String> {
+    session.set_blocking(false);
+    let result = (|| {
+        let mut output = Vec::new();
+        let mut relays = Vec::<AgentForwardRelay>::new();
+        let mut buffer = [0u8; 8192];
+
+        loop {
+            let mut progressed = false;
+            match channel.read_timeout(&mut buffer, false, Some(Duration::ZERO)) {
+                Ok(0) => {}
+                Ok(bytes) => {
+                    output.extend_from_slice(&buffer[..bytes]);
+                    progressed = true;
+                }
+                Err(libssh_rs::Error::TryAgain) => {}
+                Err(err) => {
+                    return Err(RemoteError::new_ex(
+                        RemoteErrorType::ProtocolError,
+                        format!("Could not read command output: {err}"),
+                    ));
+                }
+            }
+
+            while let Some(agent_channel) = session.accept_agent_forward() {
+                match AgentForwardRelay::connect(agent_channel) {
+                    Ok(relay) => relays.push(relay),
+                    Err(err) => warn!("Could not connect forwarded SSH agent channel: {err}"),
+                }
+                progressed = true;
+            }
+
+            let mut index = 0;
+            while index < relays.len() {
+                match relays[index].pump() {
+                    Ok((true, relay_progressed)) => {
+                        progressed |= relay_progressed;
+                        index += 1;
+                    }
+                    Ok((false, relay_progressed)) => {
+                        progressed |= relay_progressed;
+                        relays.swap_remove(index);
+                    }
+                    Err(err) => {
+                        warn!("SSH agent forwarding failed: {err}");
+                        relays.swap_remove(index);
+                    }
+                }
+            }
+
+            if channel.is_eof() {
+                break;
+            }
+            if !progressed {
+                std::thread::sleep(Duration::from_millis(2));
+            }
+        }
+
+        String::from_utf8(output).map_err(|err| {
+            RemoteError::new_ex(
+                RemoteErrorType::ProtocolError,
+                format!("Command output is not valid UTF-8: {err}"),
+            )
+        })
+    })();
+    session.set_blocking(true);
+    result
+}
+
+#[cfg(not(unix))]
+fn read_command_with_agent_forwarding(
+    _session: &libssh_rs::Session,
+    _channel: &libssh_rs::Channel,
+) -> RemoteResult<String> {
+    Err(RemoteError::new_ex(
+        RemoteErrorType::UnsupportedFeature,
+        "SSH agent forwarding is unavailable on this platform",
+    ))
 }
 
 /// Read filesize from scp header
@@ -1246,5 +1484,31 @@ mod tests {
                 .expect("failed to read default SO_KEEPALIVE")
         );
         session.disconnect().expect("failed to disconnect");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn should_forward_configured_ssh_agent() {
+        let agent = ssh_mock::TestSshAgent::start();
+        let key_file = ssh_mock::create_key_file();
+        agent.add_key(key_file.path());
+        let container = OpensshServer::start();
+        let mut config_file = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            config_file,
+            "Host forwarded\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    ForwardAgent yes",
+            port = container.port(),
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("forwarded")
+            .config_file(config_file.path(), ParseRule::STRICT)
+            .password("password");
+        let mut session = LibSshSession::connect(&opts).expect("failed to connect");
+
+        let (status, output) = session
+            .cmd("ssh-add -L")
+            .expect("failed to query remote agent");
+        assert_eq!(status, 0, "remote ssh-add failed: {output}");
+        assert!(output.contains("ssh-rsa"));
     }
 }

--- a/src/ssh/backend/libssh.rs
+++ b/src/ssh/backend/libssh.rs
@@ -16,12 +16,11 @@ use remotefs::fs::{FileType, Metadata, ReadStream, UnixPex, WriteStream};
 use remotefs::{File, RemoteError, RemoteErrorType, RemoteResult};
 use ssh2_config::{RemoteForwardDestination, RemoteForwardListen};
 
-use super::{SshSession, interface, socket};
+use super::{MAX_FORWARD_CONNECTIONS, SshSession, interface, socket};
 use crate::SshOpts;
 use crate::ssh::backend::Sftp;
 use crate::ssh::backend::forward::{
-    ChannelIo, ForwardConnection, ForwardWorker, MAX_FORWARD_CONNECTIONS,
-    tcp_remote_forward_endpoint,
+    ChannelIo, ForwardConnection, ForwardWorker, tcp_remote_forward_endpoint,
 };
 use crate::ssh::config::Config;
 
@@ -47,13 +46,21 @@ fn connect_with_timeout(
     timeout: Duration,
 ) -> libssh_rs::SshResult<()> {
     session.set_blocking(false);
-    let started = Instant::now();
+    let deadline = (!timeout.is_zero())
+        .then(|| Instant::now().checked_add(timeout))
+        .flatten();
     let result = loop {
         match session.connect() {
             Ok(()) => break Ok(()),
-            Err(libssh_rs::Error::TryAgain) if started.elapsed() < timeout => {
-                let remaining = timeout.saturating_sub(started.elapsed());
-                std::thread::sleep(Duration::from_millis(10).min(remaining));
+            Err(libssh_rs::Error::TryAgain)
+                if deadline.is_none_or(|deadline| Instant::now() < deadline) =>
+            {
+                let delay = deadline.map_or(Duration::from_millis(10), |deadline| {
+                    deadline
+                        .saturating_duration_since(Instant::now())
+                        .min(Duration::from_millis(10))
+                });
+                std::thread::sleep(delay);
             }
             Err(libssh_rs::Error::TryAgain) => {
                 break Err(libssh_rs::Error::fatal(format!(
@@ -1388,7 +1395,9 @@ fn read_command_with_agent_forwarding(
                 }
             }
 
-            while let Some(agent_channel) = session.accept_agent_forward() {
+            while relays.len() < MAX_FORWARD_CONNECTIONS
+                && let Some(agent_channel) = session.accept_agent_forward()
+            {
                 match AgentForwardRelay::connect(agent_channel) {
                     Ok(relay) => relays.push(relay),
                     Err(err) => warn!("Could not connect forwarded SSH agent channel: {err}"),
@@ -1649,6 +1658,20 @@ mod tests {
             server_elapsed < Duration::from_secs(1),
             "connection remained open after timeout: {server_elapsed:?}"
         );
+    }
+
+    #[test]
+    fn should_disable_connection_timeout_when_zero() {
+        let container = OpensshServer::start();
+        let opts = SshOpts::new("127.0.0.1")
+            .port(container.port())
+            .username("sftp")
+            .password("password")
+            .connection_timeout(Duration::ZERO);
+
+        let session = LibSshSession::connect(&opts)
+            .expect("zero connection timeout should allow the connection to complete");
+        session.disconnect().expect("failed to disconnect");
     }
 
     #[test]

--- a/src/ssh/backend/libssh.rs
+++ b/src/ssh/backend/libssh.rs
@@ -67,28 +67,40 @@ fn connect_with_timeout(
     result
 }
 
+fn configure_libssh_endpoint(
+    session: &libssh_rs::Session,
+    opts: &SshOpts,
+    ssh_config: &Config,
+) -> RemoteResult<()> {
+    session
+        .set_option(SshOption::ProcessConfig(false))
+        .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
+    session
+        .set_option(SshOption::Hostname(opts.host.clone()))
+        .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
+    if let Some(config_file) = opts.config_file.as_ref() {
+        debug!(
+            "Using config file: {config_file}",
+            config_file = config_file.display()
+        );
+        session
+            .options_parse_config(Some(config_file.to_string_lossy().as_ref()))
+            .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
+    }
+    session
+        .set_option(SshOption::Hostname(ssh_config.resolved_host.clone()))
+        .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
+    session
+        .set_option(SshOption::Port(ssh_config.port))
+        .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))
+}
+
 fn connect_libssh_session(opts: &SshOpts, ssh_config: &Config) -> RemoteResult<libssh_rs::Session> {
     let mut session = libssh_rs::Session::new().map_err(|err| {
         error!("Could not create session: {err}");
         RemoteError::new_ex(RemoteErrorType::ConnectionError, err)
     })?;
-    session
-        .set_option(SshOption::Hostname(opts.host.clone()))
-        .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
-    let config_file = opts
-        .config_file
-        .as_ref()
-        .map(|path| path.display().to_string());
-    debug!("Using config file: {config_file:?}");
-    session
-        .options_parse_config(config_file.as_deref())
-        .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
-    if let Some(port) = opts.port {
-        debug!("Using port: {port}");
-        session
-            .set_option(SshOption::Port(port))
-            .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
-    }
+    configure_libssh_endpoint(&session, opts, ssh_config)?;
 
     let bind_addresses = if ssh_config.params.bind_address.is_none()
         && let Some(bind_interface) = ssh_config.params.bind_interface.as_deref()
@@ -1559,6 +1571,55 @@ mod tests {
         let session = LibSshSession::connect(&opts)
             .expect("the explicit port should override the SSH configuration");
         session.disconnect().expect("failed to disconnect");
+    }
+
+    #[test]
+    fn should_use_resolved_endpoint_after_native_config_parsing() {
+        let container = OpensshServer::start();
+        let port = container.port();
+        let mut config_file = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            config_file,
+            "Host sftp\n    HostName 127.0.0.2\n    Port 1\n    User sftp"
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("sftp")
+            .password("password")
+            .config_file(config_file.path(), ParseRule::STRICT);
+        let mut ssh_config = Config::try_from(&opts).expect("failed to resolve SSH config");
+        ssh_config.address = format!("127.0.0.1:{port}");
+        ssh_config.port = port;
+        ssh_config.resolved_host = "127.0.0.1".to_string();
+
+        let session = connect_libssh_session(&opts, &ssh_config)
+            .expect("the resolved endpoint should override native config parsing");
+        session.disconnect();
+    }
+
+    #[test]
+    fn should_ignore_implicit_ssh_config() {
+        let container = OpensshServer::start();
+        let port = container.port();
+        let ssh_directory = tempfile::tempdir().expect("failed to create SSH directory");
+        std::fs::write(
+            ssh_directory.path().join("config"),
+            "Host 127.0.0.1\n    BindAddress 192.0.2.1\n",
+        )
+        .expect("failed to write implicit SSH config");
+        let opts = SshOpts::new("127.0.0.1").port(port);
+        let ssh_config = Config::try_from(&opts).expect("failed to resolve SSH config");
+        let session = libssh_rs::Session::new().expect("failed to create libssh session");
+        session
+            .set_option(SshOption::SshDir(Some(
+                ssh_directory.path().display().to_string(),
+            )))
+            .expect("failed to set SSH directory");
+
+        configure_libssh_endpoint(&session, &opts, &ssh_config)
+            .expect("failed to configure libssh endpoint");
+        connect_with_timeout(&session, ssh_config.connection_timeout)
+            .expect("implicit SSH config should not affect the connection");
+        session.disconnect();
     }
 
     #[test]

--- a/src/ssh/backend/libssh.rs
+++ b/src/ssh/backend/libssh.rs
@@ -110,18 +110,18 @@ impl SshSession for LibSshSession {
         session
             .set_option(SshOption::Hostname(opts.host.clone()))
             .map_err(|e| RemoteError::new_ex(RemoteErrorType::ConnectionError, e))?;
+        let config_file_str = opts.config_file.as_ref().map(|p| p.display().to_string());
+        debug!("Using config file: {:?}", config_file_str);
+        session
+            .options_parse_config(config_file_str.as_deref())
+            .map_err(|e| RemoteError::new_ex(RemoteErrorType::ConnectionError, e))?;
+
         if let Some(port) = opts.port {
             debug!("Using port: {port}");
             session
                 .set_option(SshOption::Port(port))
                 .map_err(|e| RemoteError::new_ex(RemoteErrorType::ConnectionError, e))?;
         }
-
-        let config_file_str = opts.config_file.as_ref().map(|p| p.display().to_string());
-        debug!("Using config file: {:?}", config_file_str);
-        session
-            .options_parse_config(config_file_str.as_deref())
-            .map_err(|e| RemoteError::new_ex(RemoteErrorType::ConnectionError, e))?;
 
         // set methods
         for opt in opts.methods.iter().filter_map(|method| method.ssh_opts()) {
@@ -944,5 +944,35 @@ fn wait_for_ack(channel: &libssh_rs::Channel) -> RemoteResult<()> {
         ))
     } else {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ssh2_config::ParseRule;
+    use tempfile::NamedTempFile;
+
+    use super::*;
+    use crate::ssh::container::OpensshServer;
+
+    #[test]
+    fn should_prefer_explicit_port_over_ssh_config() {
+        let container = OpensshServer::start();
+        let port = container.port();
+        let mut config_file = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            config_file,
+            "Host sftp\n    HostName 127.0.0.1\n    Port 1\n    User sftp"
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("sftp")
+            .port(port)
+            .username("sftp")
+            .password("password")
+            .config_file(config_file.path(), ParseRule::STRICT);
+
+        let session = LibSshSession::connect(&opts)
+            .expect("the explicit port should override the SSH configuration");
+        session.disconnect().expect("failed to disconnect");
     }
 }

--- a/src/ssh/backend/libssh.rs
+++ b/src/ssh/backend/libssh.rs
@@ -1,4 +1,5 @@
 use std::io::{Cursor, Read, Seek, Write};
+use std::net::ToSocketAddrs as _;
 use std::path::{Path, PathBuf};
 use std::str::FromStr as _;
 use std::time::{Duration, Instant, UNIX_EPOCH};
@@ -8,7 +9,7 @@ use remotefs::fs::stream::{ReadAndSeek, WriteAndSeek};
 use remotefs::fs::{FileType, Metadata, ReadStream, UnixPex, WriteStream};
 use remotefs::{File, RemoteError, RemoteErrorType, RemoteResult};
 
-use super::SshSession;
+use super::{SshSession, interface};
 use crate::SshOpts;
 use crate::ssh::backend::Sftp;
 use crate::ssh::config::Config;
@@ -148,6 +149,39 @@ impl SshSession for LibSshSession {
                 .set_option(SshOption::Port(port))
                 .map_err(|e| RemoteError::new_ex(RemoteErrorType::ConnectionError, e))?;
         }
+        let bind_addresses = if ssh_config.params.bind_address.is_none()
+            && let Some(bind_interface) = ssh_config.params.bind_interface.as_deref()
+        {
+            let interface_addresses = interface::addresses(bind_interface)
+                .map_err(|e| RemoteError::new_ex(RemoteErrorType::ConnectionError, e))?;
+            let target_addresses = ssh_config
+                .address
+                .to_socket_addrs()
+                .map_err(|e| RemoteError::new_ex(RemoteErrorType::BadAddress, e.to_string()))?;
+            let target_addresses = target_addresses.collect::<Vec<_>>();
+            let bind_addresses = interface_addresses
+                .into_iter()
+                .filter(|source| {
+                    target_addresses
+                        .iter()
+                        .any(|target| source.is_ipv4() == target.is_ipv4())
+                })
+                .map(|source| interface::host(&source))
+                .collect::<Vec<_>>();
+            if bind_addresses.is_empty() {
+                return Err(RemoteError::new_ex(
+                    RemoteErrorType::ConnectionError,
+                    format!(
+                        "BindInterface {bind_interface} has no address compatible with {}",
+                        ssh_config.address
+                    ),
+                ));
+            }
+            debug!("Using bind interface {bind_interface} addresses {bind_addresses:?}");
+            bind_addresses
+        } else {
+            Vec::new()
+        };
         debug!(
             "Using connection timeout: {:?}",
             ssh_config.connection_timeout
@@ -166,18 +200,33 @@ impl SshSession for LibSshSession {
 
         // Open connection and initialize handshake
         let connection_attempts = ssh_config.connection_attempts.max(1);
-        for attempt in 1..=connection_attempts {
-            match connect_with_timeout(&session, ssh_config.connection_timeout) {
-                Ok(()) => break,
-                Err(err) if attempt < connection_attempts => {
-                    warn!("SSH connection attempt {attempt} failed: {err}");
-                    session.disconnect();
+        let source_attempts = bind_addresses.len().max(1);
+        let mut last_error = None;
+        let mut connected = false;
+        'connection: for attempt in 1..=connection_attempts {
+            for source_attempt in 0..source_attempts {
+                if let Some(bind_address) = bind_addresses.get(source_attempt) {
+                    session
+                        .set_option(SshOption::BindAddress(bind_address.clone()))
+                        .map_err(|e| RemoteError::new_ex(RemoteErrorType::ConnectionError, e))?;
                 }
-                Err(err) => {
-                    error!("SSH handshake failed: {err}");
-                    return Err(RemoteError::new_ex(RemoteErrorType::ProtocolError, err));
+                match connect_with_timeout(&session, ssh_config.connection_timeout) {
+                    Ok(()) => {
+                        connected = true;
+                        break 'connection;
+                    }
+                    Err(err) => {
+                        warn!("SSH connection attempt {attempt} failed: {err}");
+                        last_error = Some(err);
+                        session.disconnect();
+                    }
                 }
             }
+        }
+        if !connected {
+            let err = last_error.expect("at least one connection was attempted");
+            error!("SSH handshake failed: {err}");
+            return Err(RemoteError::new_ex(RemoteErrorType::ProtocolError, err));
         }
 
         // try to authenticate userauth_none
@@ -1070,5 +1119,48 @@ mod tests {
         session.disconnect().expect("failed to disconnect");
         drop(session);
         proxy.join().expect("test proxy panicked");
+    }
+
+    #[test]
+    fn should_apply_configured_bind_interface() {
+        let container = OpensshServer::start();
+        let port = container.port();
+        let interface = ssh_mock::ipv4_loopback_interface();
+        let mut valid_config = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            valid_config,
+            "Host bound\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    BindInterface {interface}"
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("bound")
+            .config_file(valid_config.path(), ParseRule::STRICT)
+            .password("password");
+        let session = LibSshSession::connect(&opts)
+            .expect("failed to connect through the configured interface");
+        session.disconnect().expect("failed to disconnect");
+
+        let mut invalid_config = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            invalid_config,
+            "Host bound\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    BindInterface remotefs-ssh-missing-interface"
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("bound")
+            .config_file(invalid_config.path(), ParseRule::STRICT)
+            .password("password");
+        assert!(LibSshSession::connect(&opts).is_err());
+
+        let mut precedence_config = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            precedence_config,
+            "Host bound\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    BindAddress 127.0.0.1\n    BindInterface remotefs-ssh-missing-interface"
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("bound")
+            .config_file(precedence_config.path(), ParseRule::STRICT)
+            .password("password");
+        let session = LibSshSession::connect(&opts)
+            .expect("BindAddress should take precedence over BindInterface");
+        session.disconnect().expect("failed to disconnect");
     }
 }

--- a/src/ssh/backend/libssh.rs
+++ b/src/ssh/backend/libssh.rs
@@ -1,7 +1,7 @@
 use std::io::{Cursor, Read, Seek, Write};
 use std::path::{Path, PathBuf};
 use std::str::FromStr as _;
-use std::time::UNIX_EPOCH;
+use std::time::{Duration, Instant, UNIX_EPOCH};
 
 use libssh_rs::{AuthMethods, AuthStatus, OpenFlags, SshKey, SshOption};
 use remotefs::fs::stream::{ReadAndSeek, WriteAndSeek};
@@ -25,6 +25,31 @@ pub struct LibSshSession {
 /// See <https://docs.rs/libssh-rs/0.3.6/libssh_rs/struct.Sftp.html>
 pub struct LibSshSftp {
     inner: libssh_rs::Sftp,
+}
+
+fn connect_with_timeout(
+    session: &libssh_rs::Session,
+    timeout: Duration,
+) -> libssh_rs::SshResult<()> {
+    session.set_blocking(false);
+    let started = Instant::now();
+    let result = loop {
+        match session.connect() {
+            Ok(()) => break Ok(()),
+            Err(libssh_rs::Error::TryAgain) if started.elapsed() < timeout => {
+                let remaining = timeout.saturating_sub(started.elapsed());
+                std::thread::sleep(Duration::from_millis(10).min(remaining));
+            }
+            Err(libssh_rs::Error::TryAgain) => {
+                break Err(libssh_rs::Error::fatal(format!(
+                    "connection timed out after {timeout:?}"
+                )));
+            }
+            Err(err) => break Err(err),
+        }
+    };
+    session.set_blocking(true);
+    result
 }
 
 /// A wrapper around [`libssh_rs::Channel`] to provide a SCP recv channel for [`LibSshSession`]
@@ -96,6 +121,7 @@ impl SshSession for LibSshSession {
     fn connect(opts: &SshOpts) -> remotefs::RemoteResult<Self> {
         // Resolve host
         debug!("Connecting to '{}'", opts.host);
+        let ssh_config = Config::try_from(opts)?;
 
         // Create session
         let mut session = match libssh_rs::Session::new() {
@@ -122,6 +148,13 @@ impl SshSession for LibSshSession {
                 .set_option(SshOption::Port(port))
                 .map_err(|e| RemoteError::new_ex(RemoteErrorType::ConnectionError, e))?;
         }
+        debug!(
+            "Using connection timeout: {:?}",
+            ssh_config.connection_timeout
+        );
+        session
+            .set_option(SshOption::Timeout(ssh_config.connection_timeout))
+            .map_err(|e| RemoteError::new_ex(RemoteErrorType::ConnectionError, e))?;
 
         // set methods
         for opt in opts.methods.iter().filter_map(|method| method.ssh_opts()) {
@@ -132,7 +165,7 @@ impl SshSession for LibSshSession {
         }
 
         // Open connection and initialize handshake
-        if let Err(err) = session.connect() {
+        if let Err(err) = connect_with_timeout(&session, ssh_config.connection_timeout) {
             error!("SSH handshake failed: {err}");
             return Err(RemoteError::new_ex(RemoteErrorType::ProtocolError, err));
         }
@@ -949,10 +982,13 @@ fn wait_for_ack(channel: &libssh_rs::Channel) -> RemoteResult<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::{Duration, Instant};
+
     use ssh2_config::ParseRule;
     use tempfile::NamedTempFile;
 
     use super::*;
+    use crate::mock::ssh as ssh_mock;
     use crate::ssh::container::OpensshServer;
 
     #[test]
@@ -974,5 +1010,34 @@ mod tests {
         let session = LibSshSession::connect(&opts)
             .expect("the explicit port should override the SSH configuration");
         session.disconnect().expect("failed to disconnect");
+    }
+
+    #[test]
+    fn should_apply_explicit_connection_timeout() {
+        let (port, server) = ssh_mock::start_unresponsive_server(Duration::from_secs(2));
+        let mut config_file = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            config_file,
+            "Host unresponsive\n    HostName 127.0.0.1\n    Port {port}\n    ConnectTimeout 5"
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("unresponsive")
+            .config_file(config_file.path(), ParseRule::STRICT)
+            .connection_timeout(Duration::from_millis(100));
+
+        let started = Instant::now();
+        let result = LibSshSession::connect(&opts);
+        let elapsed = started.elapsed();
+        let server_elapsed = server.join().expect("test server panicked");
+
+        assert!(result.is_err());
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "connection exceeded explicit timeout: {elapsed:?}"
+        );
+        assert!(
+            server_elapsed < Duration::from_secs(1),
+            "connection remained open after timeout: {server_elapsed:?}"
+        );
     }
 }

--- a/src/ssh/backend/libssh.rs
+++ b/src/ssh/backend/libssh.rs
@@ -1053,6 +1053,24 @@ mod tests {
     use crate::ssh::container::OpensshServer;
 
     #[test]
+    fn should_connect_with_identity_file_from_ssh_config() {
+        let container = OpensshServer::start();
+        let key_file = ssh_mock::create_key_file();
+        let config_file =
+            ssh_mock::create_ssh_config_with_identity(container.port(), key_file.path());
+        let opts =
+            SshOpts::new("sftp").config_file(config_file.path(), ParseRule::ALLOW_UNKNOWN_FIELDS);
+
+        let session = LibSshSession::connect(&opts)
+            .expect("failed to authenticate with IdentityFile from SSH config");
+        assert!(
+            session
+                .authenticated()
+                .expect("failed to query session state")
+        );
+    }
+
+    #[test]
     fn should_prefer_explicit_port_over_ssh_config() {
         let container = OpensshServer::start();
         let port = container.port();

--- a/src/ssh/backend/libssh.rs
+++ b/src/ssh/backend/libssh.rs
@@ -6,16 +6,23 @@ use std::net::ToSocketAddrs as _;
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::str::FromStr as _;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant, UNIX_EPOCH};
 
 use libssh_rs::{AuthMethods, AuthStatus, OpenFlags, SshKey, SshOption};
 use remotefs::fs::stream::{ReadAndSeek, WriteAndSeek};
 use remotefs::fs::{FileType, Metadata, ReadStream, UnixPex, WriteStream};
 use remotefs::{File, RemoteError, RemoteErrorType, RemoteResult};
+use ssh2_config::{RemoteForwardDestination, RemoteForwardListen};
 
 use super::{SshSession, interface, socket};
 use crate::SshOpts;
 use crate::ssh::backend::Sftp;
+use crate::ssh::backend::forward::{
+    ChannelIo, ForwardConnection, ForwardWorker, MAX_FORWARD_CONNECTIONS,
+    tcp_remote_forward_endpoint,
+};
 use crate::ssh::config::Config;
 
 /// An implementation of [`SshSession`] using libssh as the backend.
@@ -24,6 +31,8 @@ use crate::ssh::config::Config;
 pub struct LibSshSession {
     session: libssh_rs::Session,
     forward_agent: bool,
+    remote_forward_ports: Vec<u16>,
+    remote_forward_worker: Option<ForwardWorker>,
 }
 
 /// A wrapper around [`libssh_rs::Sftp`] to provide a SFTP client for [`LibSshSession`]
@@ -56,6 +65,299 @@ fn connect_with_timeout(
     };
     session.set_blocking(true);
     result
+}
+
+fn connect_libssh_session(opts: &SshOpts, ssh_config: &Config) -> RemoteResult<libssh_rs::Session> {
+    let mut session = libssh_rs::Session::new().map_err(|err| {
+        error!("Could not create session: {err}");
+        RemoteError::new_ex(RemoteErrorType::ConnectionError, err)
+    })?;
+    session
+        .set_option(SshOption::Hostname(opts.host.clone()))
+        .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
+    let config_file = opts
+        .config_file
+        .as_ref()
+        .map(|path| path.display().to_string());
+    debug!("Using config file: {config_file:?}");
+    session
+        .options_parse_config(config_file.as_deref())
+        .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
+    if let Some(port) = opts.port {
+        debug!("Using port: {port}");
+        session
+            .set_option(SshOption::Port(port))
+            .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
+    }
+
+    let bind_addresses = if ssh_config.params.bind_address.is_none()
+        && let Some(bind_interface) = ssh_config.params.bind_interface.as_deref()
+    {
+        let interface_addresses = interface::addresses(bind_interface)
+            .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
+        let target_addresses = ssh_config
+            .address
+            .to_socket_addrs()
+            .map_err(|err| RemoteError::new_ex(RemoteErrorType::BadAddress, err.to_string()))?
+            .collect::<Vec<_>>();
+        let bind_addresses = interface_addresses
+            .into_iter()
+            .filter(|source| {
+                target_addresses
+                    .iter()
+                    .any(|target| source.is_ipv4() == target.is_ipv4())
+            })
+            .map(|source| interface::host(&source))
+            .collect::<Vec<_>>();
+        if bind_addresses.is_empty() {
+            return Err(RemoteError::new_ex(
+                RemoteErrorType::ConnectionError,
+                format!(
+                    "BindInterface {bind_interface} has no address compatible with {}",
+                    ssh_config.address
+                ),
+            ));
+        }
+        debug!("Using bind interface {bind_interface} addresses {bind_addresses:?}");
+        bind_addresses
+    } else {
+        Vec::new()
+    };
+    session
+        .set_option(SshOption::Timeout(ssh_config.connection_timeout))
+        .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
+    for option in opts.methods.iter().filter_map(|method| method.ssh_opts()) {
+        debug!("Setting SSH option: {option:?}");
+        session
+            .set_option(option)
+            .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
+    }
+
+    let connection_attempts = ssh_config.connection_attempts.max(1);
+    let source_attempts = bind_addresses.len().max(1);
+    let mut last_error = None;
+    let mut connected = false;
+    'connection: for attempt in 1..=connection_attempts {
+        for source_attempt in 0..source_attempts {
+            if let Some(bind_address) = bind_addresses.get(source_attempt) {
+                session
+                    .set_option(SshOption::BindAddress(bind_address.clone()))
+                    .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
+            }
+            match connect_with_timeout(&session, ssh_config.connection_timeout) {
+                Ok(()) => {
+                    connected = true;
+                    break 'connection;
+                }
+                Err(err) => {
+                    warn!("SSH connection attempt {attempt} failed: {err}");
+                    last_error = Some(err);
+                    session.disconnect();
+                }
+            }
+        }
+    }
+    if !connected {
+        let err = last_error.expect("at least one connection was attempted");
+        error!("SSH handshake failed: {err}");
+        return Err(RemoteError::new_ex(RemoteErrorType::ProtocolError, err));
+    }
+    socket::set_keepalive(&session, ssh_config.params.tcp_keep_alive.unwrap_or(true))
+        .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
+    authenticate(&mut session, opts)?;
+    Ok(session)
+}
+
+#[derive(Clone)]
+struct LibSshForwardRoute {
+    port: u16,
+    destination: Option<RemoteForwardDestination>,
+    connect_timeout: Duration,
+}
+
+impl ChannelIo for libssh_rs::Channel {
+    fn read_channel(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        self.read_timeout(buffer, false, Some(Duration::ZERO))
+            .map_err(Into::into)
+    }
+
+    fn write_channel(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        self.stdin().write(buffer)
+    }
+
+    fn is_eof(&self) -> bool {
+        libssh_rs::Channel::is_eof(self)
+    }
+
+    fn send_eof(&mut self) -> std::io::Result<()> {
+        libssh_rs::Channel::send_eof(self).map_err(Into::into)
+    }
+
+    fn close(&mut self) {
+        let _ = libssh_rs::Channel::close(self);
+    }
+}
+
+fn setup_libssh_remote_forwards(
+    opts: &SshOpts,
+    config: &Config,
+) -> RemoteResult<(Option<ForwardWorker>, Vec<u16>)> {
+    if config.params.remote_forward.is_empty() {
+        return Ok((None, Vec::new()));
+    }
+    #[cfg(not(unix))]
+    if config.params.remote_forward.iter().any(|forward| {
+        matches!(
+            forward.destination,
+            Some(RemoteForwardDestination::UnixSocket(_))
+        )
+    }) {
+        return Err(RemoteError::new_ex(
+            RemoteErrorType::UnsupportedFeature,
+            "Unix socket RemoteForward destinations are unavailable on this platform",
+        ));
+    }
+    if let Some(forward) = config
+        .params
+        .remote_forward
+        .iter()
+        .find(|forward| matches!(forward.listen, RemoteForwardListen::UnixSocket(_)))
+    {
+        return Err(RemoteError::new_ex(
+            RemoteErrorType::UnsupportedFeature,
+            format!(
+                "libssh cannot create Unix socket RemoteForward listener {}",
+                forward.listen
+            ),
+        ));
+    }
+    for (index, forward) in config.params.remote_forward.iter().enumerate() {
+        let Some((_, port)) = tcp_remote_forward_endpoint(&forward.listen) else {
+            unreachable!("Unix socket listeners were rejected above");
+        };
+        if port != 0
+            && config.params.remote_forward[..index].iter().any(|other| {
+                tcp_remote_forward_endpoint(&other.listen)
+                    .is_some_and(|(_, other_port)| other_port == port)
+            })
+        {
+            return Err(RemoteError::new_ex(
+                RemoteErrorType::UnsupportedFeature,
+                format!(
+                    "libssh cannot distinguish multiple RemoteForward listeners on port {port}"
+                ),
+            ));
+        }
+    }
+
+    let session = connect_libssh_session(opts, config)?;
+    let mut routes = Vec::<LibSshForwardRoute>::new();
+    for forward in &config.params.remote_forward {
+        let (mut bind_address, port) = tcp_remote_forward_endpoint(&forward.listen)
+            .expect("Unix socket listeners were rejected above");
+        if bind_address.is_some_and(|address| address.is_empty() || address == "*") {
+            bind_address = None;
+        }
+        let returned_port = session.listen_forward(bind_address, port).map_err(|err| {
+            RemoteError::new_ex(
+                RemoteErrorType::ProtocolError,
+                format!(
+                    "Could not configure RemoteForward {}: {err}",
+                    forward.listen
+                ),
+            )
+        })?;
+        let actual_port = if port == 0 { returned_port } else { port };
+        if routes.iter().any(|route| route.port == actual_port) {
+            session.disconnect();
+            return Err(RemoteError::new_ex(
+                RemoteErrorType::UnsupportedFeature,
+                format!(
+                    "libssh cannot distinguish multiple RemoteForward listeners on port {actual_port}"
+                ),
+            ));
+        }
+        debug!(
+            "RemoteForward {} listening on assigned port {actual_port}",
+            forward.listen
+        );
+        routes.push(LibSshForwardRoute {
+            port: actual_port,
+            destination: forward.destination.clone(),
+            connect_timeout: config.connection_timeout,
+        });
+    }
+
+    session.set_blocking(false);
+    let remote_forward_ports = routes.iter().map(|route| route.port).collect();
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let worker_cancelled = cancelled.clone();
+    let worker = std::thread::spawn(move || {
+        let mut connections = Vec::<ForwardConnection<libssh_rs::Channel>>::new();
+        'forwarding: while !worker_cancelled.load(Ordering::Acquire) {
+            let mut progressed = false;
+            while connections.len() < MAX_FORWARD_CONNECTIONS {
+                match session.accept_forward(Duration::ZERO) {
+                    Ok((port, channel)) => {
+                        let Some(route) = routes.iter().find(|route| route.port == port) else {
+                            warn!("Received RemoteForward connection for unknown port {port}");
+                            continue;
+                        };
+                        let connection = match &route.destination {
+                            Some(destination) => ForwardConnection::fixed(
+                                channel,
+                                destination,
+                                route.connect_timeout,
+                                Arc::clone(&worker_cancelled),
+                            ),
+                            None => Ok(ForwardConnection::dynamic(
+                                channel,
+                                route.connect_timeout,
+                                Arc::clone(&worker_cancelled),
+                            )),
+                        };
+                        match connection {
+                            Ok(connection) => connections.push(connection),
+                            Err(err) => warn!("Could not queue RemoteForward destination: {err}"),
+                        }
+                        progressed = true;
+                    }
+                    Err(libssh_rs::Error::TryAgain) => break,
+                    Err(err) => {
+                        warn!("Could not accept RemoteForward connection: {err}");
+                        break 'forwarding;
+                    }
+                }
+            }
+
+            let mut index = 0;
+            while index < connections.len() {
+                match connections[index].pump() {
+                    Ok((true, connection_progressed)) => {
+                        progressed |= connection_progressed;
+                        index += 1;
+                    }
+                    Ok((false, connection_progressed)) => {
+                        progressed |= connection_progressed;
+                        connections.swap_remove(index);
+                    }
+                    Err(err) => {
+                        warn!("RemoteForward connection failed: {err}");
+                        connections.swap_remove(index);
+                    }
+                }
+            }
+            if !progressed {
+                std::thread::sleep(Duration::from_millis(2));
+            }
+        }
+        drop(connections);
+        session.disconnect();
+    });
+    Ok((
+        Some(ForwardWorker::new(cancelled, worker)),
+        remote_forward_ports,
+    ))
 }
 
 /// A wrapper around [`libssh_rs::Channel`] to provide a SCP recv channel for [`LibSshSession`]
@@ -128,123 +430,18 @@ impl SshSession for LibSshSession {
         // Resolve host
         debug!("Connecting to '{}'", opts.host);
         let ssh_config = Config::try_from(opts)?;
-
-        // Create session
-        let mut session = match libssh_rs::Session::new() {
-            Ok(s) => s,
-            Err(err) => {
-                error!("Could not create session: {err}");
-                return Err(RemoteError::new_ex(RemoteErrorType::ConnectionError, err));
-            }
-        };
-
-        // set hostname
-        session
-            .set_option(SshOption::Hostname(opts.host.clone()))
-            .map_err(|e| RemoteError::new_ex(RemoteErrorType::ConnectionError, e))?;
-        let config_file_str = opts.config_file.as_ref().map(|p| p.display().to_string());
-        debug!("Using config file: {:?}", config_file_str);
-        session
-            .options_parse_config(config_file_str.as_deref())
-            .map_err(|e| RemoteError::new_ex(RemoteErrorType::ConnectionError, e))?;
-
-        if let Some(port) = opts.port {
-            debug!("Using port: {port}");
-            session
-                .set_option(SshOption::Port(port))
-                .map_err(|e| RemoteError::new_ex(RemoteErrorType::ConnectionError, e))?;
-        }
-        let bind_addresses = if ssh_config.params.bind_address.is_none()
-            && let Some(bind_interface) = ssh_config.params.bind_interface.as_deref()
-        {
-            let interface_addresses = interface::addresses(bind_interface)
-                .map_err(|e| RemoteError::new_ex(RemoteErrorType::ConnectionError, e))?;
-            let target_addresses = ssh_config
-                .address
-                .to_socket_addrs()
-                .map_err(|e| RemoteError::new_ex(RemoteErrorType::BadAddress, e.to_string()))?;
-            let target_addresses = target_addresses.collect::<Vec<_>>();
-            let bind_addresses = interface_addresses
-                .into_iter()
-                .filter(|source| {
-                    target_addresses
-                        .iter()
-                        .any(|target| source.is_ipv4() == target.is_ipv4())
-                })
-                .map(|source| interface::host(&source))
-                .collect::<Vec<_>>();
-            if bind_addresses.is_empty() {
-                return Err(RemoteError::new_ex(
-                    RemoteErrorType::ConnectionError,
-                    format!(
-                        "BindInterface {bind_interface} has no address compatible with {}",
-                        ssh_config.address
-                    ),
-                ));
-            }
-            debug!("Using bind interface {bind_interface} addresses {bind_addresses:?}");
-            bind_addresses
-        } else {
-            Vec::new()
-        };
-        debug!(
-            "Using connection timeout: {:?}",
-            ssh_config.connection_timeout
-        );
-        session
-            .set_option(SshOption::Timeout(ssh_config.connection_timeout))
-            .map_err(|e| RemoteError::new_ex(RemoteErrorType::ConnectionError, e))?;
-
-        // set methods
-        for opt in opts.methods.iter().filter_map(|method| method.ssh_opts()) {
-            debug!("Setting SSH option: {opt:?}");
-            session
-                .set_option(opt)
-                .map_err(|e| RemoteError::new_ex(RemoteErrorType::ConnectionError, e))?;
-        }
-
-        // Open connection and initialize handshake
-        let connection_attempts = ssh_config.connection_attempts.max(1);
-        let source_attempts = bind_addresses.len().max(1);
-        let mut last_error = None;
-        let mut connected = false;
-        'connection: for attempt in 1..=connection_attempts {
-            for source_attempt in 0..source_attempts {
-                if let Some(bind_address) = bind_addresses.get(source_attempt) {
-                    session
-                        .set_option(SshOption::BindAddress(bind_address.clone()))
-                        .map_err(|e| RemoteError::new_ex(RemoteErrorType::ConnectionError, e))?;
-                }
-                match connect_with_timeout(&session, ssh_config.connection_timeout) {
-                    Ok(()) => {
-                        connected = true;
-                        break 'connection;
-                    }
-                    Err(err) => {
-                        warn!("SSH connection attempt {attempt} failed: {err}");
-                        last_error = Some(err);
-                        session.disconnect();
-                    }
-                }
-            }
-        }
-        if !connected {
-            let err = last_error.expect("at least one connection was attempted");
-            error!("SSH handshake failed: {err}");
-            return Err(RemoteError::new_ex(RemoteErrorType::ProtocolError, err));
-        }
-        socket::set_keepalive(&session, ssh_config.params.tcp_keep_alive.unwrap_or(true))
-            .map_err(|e| RemoteError::new_ex(RemoteErrorType::ConnectionError, e))?;
-
-        // try to authenticate userauth_none
-        authenticate(&mut session, opts)?;
+        let session = connect_libssh_session(opts, &ssh_config)?;
 
         let forward_agent = ssh_config.params.forward_agent.unwrap_or(false);
         session.enable_accept_agent_forward(forward_agent);
+        let (remote_forward_worker, remote_forward_ports) =
+            setup_libssh_remote_forwards(opts, &ssh_config)?;
 
         Ok(Self {
             session,
             forward_agent,
+            remote_forward_ports,
+            remote_forward_worker,
         })
     }
 
@@ -262,9 +459,16 @@ impl SshSession for LibSshSession {
     }
 
     fn disconnect(&self) -> RemoteResult<()> {
+        if let Some(worker) = &self.remote_forward_worker {
+            worker.stop();
+        }
         self.session.disconnect();
 
         Ok(())
+    }
+
+    fn remote_forward_ports(&self) -> &[u16] {
+        &self.remote_forward_ports
     }
 
     fn cmd<S>(&mut self, cmd: S) -> RemoteResult<(u32, String)>
@@ -1510,5 +1714,75 @@ mod tests {
             .expect("failed to query remote agent");
         assert_eq!(status, 0, "remote ssh-add failed: {output}");
         assert!(output.contains("ssh-rsa"));
+    }
+
+    #[test]
+    fn should_apply_configured_remote_forward() {
+        crate::mock::logger();
+        let container = OpensshServer::start_with_tcp_forwarding();
+        let (destination_port, destination) = ssh_mock::start_tcp_echo_server();
+        let (dynamic_destination_port, dynamic_destination) = ssh_mock::start_tcp_echo_server();
+        let remote_port = 43002;
+        let mut config_file = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            config_file,
+            "Host forwarded\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    RemoteForward 127.0.0.1:{remote_port} 127.0.0.1:{destination_port}\n    RemoteForward 0",
+            port = container.port(),
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("forwarded")
+            .config_file(config_file.path(), ParseRule::STRICT)
+            .password("password");
+        let mut session = LibSshSession::connect(&opts).expect("failed to connect");
+        let dynamic_port = *session
+            .remote_forward_ports()
+            .get(1)
+            .expect("dynamic RemoteForward did not report its assigned port");
+
+        let (status, output) = session
+            .cmd(format!("printf ping | nc -w 5 127.0.0.1 {remote_port}"))
+            .expect("failed to use configured remote forward");
+        assert_eq!(status, 0, "remote forwarding command failed: {output}");
+        assert_eq!(output, "pong\n");
+        destination.join().expect("TCP echo server panicked");
+
+        let (status, output) = session
+            .cmd(ssh_mock::socks5_test_command(
+                dynamic_port,
+                dynamic_destination_port,
+            ))
+            .expect("failed to use dynamic RemoteForward");
+        assert_eq!(status, 0, "dynamic forwarding command failed: {output}");
+        assert_eq!(output, "pong\n");
+        dynamic_destination
+            .join()
+            .expect("dynamic TCP echo server panicked");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn should_apply_remote_forward_to_unix_socket() {
+        let container = OpensshServer::start_with_tcp_forwarding();
+        let (_directory, destination_path, destination) = ssh_mock::start_unix_echo_server();
+        let remote_port = 43202;
+        let mut config_file = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            config_file,
+            "Host forwarded\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    RemoteForward 127.0.0.1:{remote_port} {destination}",
+            port = container.port(),
+            destination = destination_path.display(),
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("forwarded")
+            .config_file(config_file.path(), ParseRule::STRICT)
+            .password("password");
+        let mut session = LibSshSession::connect(&opts).expect("failed to connect");
+
+        let (status, output) = session
+            .cmd(format!("printf ping | nc -w 5 127.0.0.1 {remote_port}"))
+            .expect("failed to use Unix destination RemoteForward");
+        assert_eq!(status, 0, "remote forwarding command failed: {output}");
+        assert_eq!(output, "pong\n");
+        destination.join().expect("Unix echo server panicked");
     }
 }

--- a/src/ssh/backend/libssh.rs
+++ b/src/ssh/backend/libssh.rs
@@ -825,7 +825,9 @@ fn authenticate(session: &mut libssh_rs::Session, opts: &SshOpts) -> RemoteResul
         .map_err(|e| RemoteError::new_ex(RemoteErrorType::AuthenticationFailed, e))?;
     debug!("Available authentication methods: {auth_methods:?}");
 
-    if auth_methods.contains(AuthMethods::PUBLIC_KEY) {
+    if ssh_config.params.pubkey_authentication.unwrap_or(true)
+        && auth_methods.contains(AuthMethods::PUBLIC_KEY)
+    {
         debug!("Trying public key authentication");
         // try with known key to config
         match session.userauth_public_key_auto(None, None) {
@@ -1063,6 +1065,32 @@ mod tests {
 
         let session = LibSshSession::connect(&opts)
             .expect("failed to authenticate with IdentityFile from SSH config");
+        assert!(
+            session
+                .authenticated()
+                .expect("failed to query session state")
+        );
+    }
+
+    #[test]
+    fn should_disable_public_key_authentication_from_ssh_config() {
+        let container = OpensshServer::start();
+        let key_file = ssh_mock::create_key_file();
+        let config_file = ssh_mock::create_ssh_config_with_identity_and_pubkey_authentication(
+            container.port(),
+            key_file.path(),
+            false,
+        );
+        let opts =
+            SshOpts::new("sftp").config_file(config_file.path(), ParseRule::ALLOW_UNKNOWN_FIELDS);
+
+        assert!(LibSshSession::connect(&opts).is_err());
+
+        let opts = SshOpts::new("sftp")
+            .config_file(config_file.path(), ParseRule::ALLOW_UNKNOWN_FIELDS)
+            .password("password");
+        let session =
+            LibSshSession::connect(&opts).expect("password authentication should remain enabled");
         assert!(
             session
                 .authenticated()

--- a/src/ssh/backend/libssh.rs
+++ b/src/ssh/backend/libssh.rs
@@ -165,9 +165,19 @@ impl SshSession for LibSshSession {
         }
 
         // Open connection and initialize handshake
-        if let Err(err) = connect_with_timeout(&session, ssh_config.connection_timeout) {
-            error!("SSH handshake failed: {err}");
-            return Err(RemoteError::new_ex(RemoteErrorType::ProtocolError, err));
+        let connection_attempts = ssh_config.connection_attempts.max(1);
+        for attempt in 1..=connection_attempts {
+            match connect_with_timeout(&session, ssh_config.connection_timeout) {
+                Ok(()) => break,
+                Err(err) if attempt < connection_attempts => {
+                    warn!("SSH connection attempt {attempt} failed: {err}");
+                    session.disconnect();
+                }
+                Err(err) => {
+                    error!("SSH handshake failed: {err}");
+                    return Err(RemoteError::new_ex(RemoteErrorType::ProtocolError, err));
+                }
+            }
         }
 
         // try to authenticate userauth_none
@@ -1039,5 +1049,26 @@ mod tests {
             server_elapsed < Duration::from_secs(1),
             "connection remained open after timeout: {server_elapsed:?}"
         );
+    }
+
+    #[test]
+    fn should_retry_connection_using_configured_attempts() {
+        let container = OpensshServer::start();
+        let (port, proxy) = ssh_mock::start_flaky_proxy(container.port(), 1);
+        let mut config_file = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            config_file,
+            "Host flaky\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    ConnectionAttempts 2"
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("flaky")
+            .config_file(config_file.path(), ParseRule::STRICT)
+            .password("password");
+
+        let session = LibSshSession::connect(&opts)
+            .expect("connection should succeed on the configured retry");
+        session.disconnect().expect("failed to disconnect");
+        drop(session);
+        proxy.join().expect("test proxy panicked");
     }
 }

--- a/src/ssh/backend/libssh2.rs
+++ b/src/ssh/backend/libssh2.rs
@@ -10,7 +10,7 @@ use remotefs::{File, RemoteError, RemoteErrorType, RemoteResult};
 use socket2::{Domain, Protocol, Socket, Type};
 use ssh2::{FileStat, OpenType, RenameFlags};
 
-use super::SshSession;
+use super::{SshSession, interface};
 use crate::ssh::backend::Sftp;
 use crate::ssh::config::Config;
 use crate::{SshAgentIdentity, SshOpts};
@@ -63,6 +63,7 @@ impl SshSession for LibSsh2Session {
                     socket_addr,
                     ssh_config.connection_timeout,
                     ssh_config.params.bind_address.as_deref(),
+                    ssh_config.params.bind_interface.as_deref(),
                 ) {
                     Ok(tcp_stream) => {
                         debug!("Connection established with address {socket_addr}");
@@ -591,18 +592,27 @@ fn tcp_connect(
     address: &SocketAddr,
     timeout: Duration,
     bind_address: Option<&str>,
+    bind_interface: Option<&str>,
 ) -> std::io::Result<TcpStream> {
-    let Some(bind_address) = bind_address else {
+    if bind_address.is_none() && bind_interface.is_none() {
         return if timeout.is_zero() {
             TcpStream::connect(address)
         } else {
             TcpStream::connect_timeout(address, timeout)
         };
+    }
+
+    let source_addresses = if let Some(bind_address) = bind_address {
+        (bind_address, 0).to_socket_addrs()?.collect::<Vec<_>>()
+    } else {
+        interface::addresses(bind_interface.expect("checked above"))?
+            .into_iter()
+            .collect()
     };
 
     let mut last_error = None;
-    for source_address in (bind_address, 0)
-        .to_socket_addrs()?
+    for source_address in source_addresses
+        .into_iter()
         .filter(|source| source.is_ipv4() == address.is_ipv4())
     {
         let result = (|| {
@@ -624,10 +634,14 @@ fn tcp_connect(
             Err(err) => last_error = Some(err),
         }
     }
+    let source = bind_address.map_or_else(
+        || format!("BindInterface {}", bind_interface.expect("checked above")),
+        |address| format!("BindAddress {address}"),
+    );
     Err(last_error.unwrap_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::AddrNotAvailable,
-            format!("no {address} address family found for BindAddress {bind_address}"),
+            format!("no {address} address family found for {source}"),
         )
     }))
 }
@@ -949,6 +963,49 @@ mod test {
         writeln!(
             invalid_config,
             "Host bound\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    BindAddress 192.0.2.1"
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("bound")
+            .config_file(invalid_config.path(), ParseRule::STRICT)
+            .password("password");
+        assert!(LibSsh2Session::connect(&opts).is_err());
+
+        let mut precedence_config = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            precedence_config,
+            "Host bound\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    BindAddress 127.0.0.1\n    BindInterface remotefs-ssh-missing-interface"
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("bound")
+            .config_file(precedence_config.path(), ParseRule::STRICT)
+            .password("password");
+        let session = LibSsh2Session::connect(&opts)
+            .expect("BindAddress should take precedence over BindInterface");
+        session.disconnect().expect("failed to disconnect");
+    }
+
+    #[test]
+    fn should_apply_configured_bind_interface() {
+        let container = crate::ssh::container::OpensshServer::start();
+        let port = container.port();
+        let interface = ssh_mock::ipv4_loopback_interface();
+        let mut valid_config = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            valid_config,
+            "Host bound\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    BindInterface {interface}"
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("bound")
+            .config_file(valid_config.path(), ParseRule::STRICT)
+            .password("password");
+        let session = LibSsh2Session::connect(&opts)
+            .expect("failed to connect through the configured interface");
+        session.disconnect().expect("failed to disconnect");
+
+        let mut invalid_config = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            invalid_config,
+            "Host bound\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    BindInterface remotefs-ssh-missing-interface"
         )
         .expect("failed to write SSH config");
         let opts = SshOpts::new("bound")

--- a/src/ssh/backend/libssh2.rs
+++ b/src/ssh/backend/libssh2.rs
@@ -117,7 +117,12 @@ impl SshSession for LibSsh2Session {
 
         // if use_ssh_agent is enabled, try to authenticate with ssh agent
         if pubkey_authentication && let Some(ssh_agent_config) = &opts.ssh_agent_identity {
-            match session_auth_with_agent(&mut session, &ssh_config.username, ssh_agent_config) {
+            match session_auth_with_agent(
+                &mut session,
+                &ssh_config.username,
+                ssh_agent_config,
+                ssh_config.params.pubkey_accepted_algorithms.algorithms(),
+            ) {
                 Ok(_) => {
                     info!("Authenticated with ssh agent");
                     return Ok(Self { session });
@@ -685,6 +690,14 @@ fn set_algo_prefs(
         return Err(RemoteError::new_ex(RemoteErrorType::ProtocolError, err));
     }
 
+    // Public key signature algorithms
+    let algos = libssh2_signature_algorithms(params.pubkey_accepted_algorithms.algorithms());
+    trace!("Configuring public key signature algorithms: {algos}");
+    if let Err(err) = session.method_pref(ssh2::MethodType::SignAlgo, algos.as_str()) {
+        error!("Could not set public key signature algorithms: {err}");
+        return Err(RemoteError::new_ex(RemoteErrorType::ProtocolError, err));
+    }
+
     // ciphers
     let algos = params.ciphers.algorithms().join(",");
     trace!("Configuring Crypt algorithms: {algos}");
@@ -721,11 +734,31 @@ fn set_algo_prefs(
     Ok(())
 }
 
+/// Convert OpenSSH certificate algorithm names to libssh2 RSA signature names.
+fn libssh2_signature_algorithms(configured_algorithms: &[String]) -> String {
+    let mut algorithms = Vec::with_capacity(configured_algorithms.len());
+
+    for configured_algorithm in configured_algorithms {
+        let algorithm = match configured_algorithm.as_str() {
+            "rsa-sha2-512-cert-v01@openssh.com" => "rsa-sha2-512",
+            "rsa-sha2-256-cert-v01@openssh.com" => "rsa-sha2-256",
+            "ssh-rsa-cert-v01@openssh.com" => "ssh-rsa",
+            algorithm => algorithm,
+        };
+        if !algorithms.contains(&algorithm) {
+            algorithms.push(algorithm);
+        }
+    }
+
+    algorithms.join(",")
+}
+
 /// Authenticate on session with ssh agent
 fn session_auth_with_agent(
     session: &mut ssh2::Session,
     username: &str,
     ssh_agent_config: &SshAgentIdentity,
+    accepted_algorithms: &[String],
 ) -> RemoteResult<()> {
     let mut agent = session
         .agent()
@@ -745,6 +778,10 @@ fn session_auth_with_agent(
         .identities()
         .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?
     {
+        if !public_key_blob_is_accepted(identity.blob(), accepted_algorithms) {
+            debug!("Skipping SSH agent identity excluded by PubkeyAcceptedAlgorithms");
+            continue;
+        }
         if ssh_agent_config.pubkey_matches(identity.blob()) {
             debug!("Trying to authenticate with ssh agent with key: {identity:?}");
         } else {
@@ -779,7 +816,16 @@ fn session_auth_with_rsakey(
     username: &str,
     private_key: &Path,
     password: Option<&str>,
+    accepted_algorithms: &[String],
 ) -> RemoteResult<()> {
+    let private_key_algorithm = private_key_algorithm(private_key, password)?;
+    if !pubkey_algorithm_is_accepted(&private_key_algorithm, accepted_algorithms) {
+        return Err(RemoteError::new_ex(
+            RemoteErrorType::AuthenticationFailed,
+            format!("private key algorithm {private_key_algorithm} is not accepted by SSH config"),
+        ));
+    }
+
     debug!("Authenticating with username '{username}' and RSA key");
     trace!(
         "Trying to authenticate with RSA key at '{}'",
@@ -807,11 +853,149 @@ fn session_auth(
             &ssh_config.username,
             private_key.as_path(),
             opts.password.as_deref(),
+            ssh_config.params.pubkey_accepted_algorithms.algorithms(),
         ),
         Authentication::Password(password) => {
             session_auth_with_password(session, &ssh_config.username, &password)
         }
     }
+}
+
+/// Read the algorithm from an OpenSSH or PEM private key.
+fn private_key_algorithm(
+    private_key: &Path,
+    password: Option<&str>,
+) -> RemoteResult<ssh_key::Algorithm> {
+    if let Ok(key) = ssh_key::PrivateKey::read_openssh_file(private_key) {
+        return Ok(key.algorithm());
+    }
+
+    let pem = std::fs::read(private_key).map_err(|err| {
+        RemoteError::new_ex(
+            RemoteErrorType::AuthenticationFailed,
+            format!(
+                "could not read private key at '{}': {err}",
+                private_key.display()
+            ),
+        )
+    })?;
+    let key = password
+        .and_then(|password| {
+            openssl::pkey::PKey::private_key_from_pem_passphrase(&pem, password.as_bytes()).ok()
+        })
+        .or_else(|| openssl::pkey::PKey::private_key_from_pem(&pem).ok())
+        .ok_or_else(|| {
+            RemoteError::new_ex(
+                RemoteErrorType::AuthenticationFailed,
+                format!(
+                    "could not inspect private key at '{}' for PubkeyAcceptedAlgorithms",
+                    private_key.display()
+                ),
+            )
+        })?;
+
+    openssl_key_algorithm(&key).ok_or_else(|| {
+        RemoteError::new_ex(
+            RemoteErrorType::AuthenticationFailed,
+            format!(
+                "private key at '{}' uses an unsupported algorithm",
+                private_key.display()
+            ),
+        )
+    })
+}
+
+/// Convert an OpenSSL private key identifier to its SSH algorithm.
+fn openssl_key_algorithm(
+    key: &openssl::pkey::PKey<openssl::pkey::Private>,
+) -> Option<ssh_key::Algorithm> {
+    use openssl::pkey::Id;
+    use ssh_key::{Algorithm, EcdsaCurve};
+
+    match key.id() {
+        Id::RSA | Id::RSA_PSS => Some(Algorithm::Rsa { hash: None }),
+        Id::DSA => Some(Algorithm::Dsa),
+        Id::ED25519 => Some(Algorithm::Ed25519),
+        Id::EC => {
+            let curve = match key.ec_key().ok()?.group().curve_name()? {
+                openssl::nid::Nid::X9_62_PRIME256V1 => EcdsaCurve::NistP256,
+                openssl::nid::Nid::SECP384R1 => EcdsaCurve::NistP384,
+                openssl::nid::Nid::SECP521R1 => EcdsaCurve::NistP521,
+                _ => return None,
+            };
+            Some(Algorithm::Ecdsa { curve })
+        }
+        _ => None,
+    }
+}
+
+/// Return whether a public key algorithm is allowed by the configured list.
+fn pubkey_algorithm_is_accepted(
+    key_algorithm: &ssh_key::Algorithm,
+    accepted_algorithms: &[String],
+) -> bool {
+    if matches!(key_algorithm, ssh_key::Algorithm::Rsa { .. }) {
+        accepted_algorithms.iter().any(|algorithm| {
+            matches!(
+                algorithm.as_str(),
+                "rsa-sha2-512" | "rsa-sha2-256" | "ssh-rsa"
+            )
+        })
+    } else {
+        accepted_algorithms
+            .iter()
+            .any(|algorithm| algorithm == key_algorithm.as_ref())
+    }
+}
+
+/// Return whether the exact algorithm named by an SSH public key blob is accepted.
+fn public_key_blob_is_accepted(blob: &[u8], accepted_algorithms: &[String]) -> bool {
+    let Some(name_length) = blob.get(..4) else {
+        return false;
+    };
+    let name_length = u32::from_be_bytes(
+        name_length
+            .try_into()
+            .expect("the public key algorithm length is four bytes"),
+    ) as usize;
+    let Some(name_end) = 4_usize.checked_add(name_length) else {
+        return false;
+    };
+    let Some(name) = blob.get(4..name_end) else {
+        return false;
+    };
+    let Ok(name) = std::str::from_utf8(name) else {
+        return false;
+    };
+
+    public_key_blob_algorithm_is_accepted(name, accepted_algorithms)
+}
+
+/// Return whether a public key blob algorithm is allowed by the configured list.
+fn public_key_blob_algorithm_is_accepted(
+    key_algorithm: &str,
+    accepted_algorithms: &[String],
+) -> bool {
+    const RSA_ALGORITHMS: [&str; 3] = ["rsa-sha2-512", "rsa-sha2-256", "ssh-rsa"];
+    const RSA_CERTIFICATE_ALGORITHMS: [&str; 3] = [
+        "rsa-sha2-512-cert-v01@openssh.com",
+        "rsa-sha2-256-cert-v01@openssh.com",
+        "ssh-rsa-cert-v01@openssh.com",
+    ];
+
+    let equivalent_algorithms = if RSA_ALGORITHMS.contains(&key_algorithm) {
+        &RSA_ALGORITHMS
+    } else if RSA_CERTIFICATE_ALGORITHMS.contains(&key_algorithm) {
+        &RSA_CERTIFICATE_ALGORITHMS
+    } else {
+        return accepted_algorithms
+            .iter()
+            .any(|algorithm| algorithm == key_algorithm);
+    };
+
+    accepted_algorithms
+        .iter()
+        .any(|algorithm| equivalent_algorithms.contains(&algorithm.as_str()))
 }
 
 /// Authenticate on session with username and password
@@ -841,6 +1025,85 @@ mod test {
 
     use super::*;
     use crate::mock::ssh as ssh_mock;
+
+    #[test]
+    fn should_filter_non_rsa_pubkey_algorithms() {
+        let rsa_only = vec!["rsa-sha2-256".to_string()];
+        let ed25519_only = vec!["ssh-ed25519".to_string()];
+
+        assert!(!pubkey_algorithm_is_accepted(
+            &ssh_key::Algorithm::Ed25519,
+            &rsa_only,
+        ));
+        assert!(pubkey_algorithm_is_accepted(
+            &ssh_key::Algorithm::Ed25519,
+            &ed25519_only,
+        ));
+        assert!(pubkey_algorithm_is_accepted(
+            &ssh_key::Algorithm::Rsa { hash: None },
+            &rsa_only,
+        ));
+    }
+
+    #[test]
+    fn should_distinguish_plain_and_certificate_pubkey_algorithms() {
+        let ed25519_only = vec!["ssh-ed25519".to_string()];
+        let ed25519_certificate_only = vec!["ssh-ed25519-cert-v01@openssh.com".to_string()];
+        let rsa_only = vec!["rsa-sha2-256".to_string()];
+        let rsa_certificate_only = vec!["rsa-sha2-256-cert-v01@openssh.com".to_string()];
+
+        assert!(!public_key_blob_algorithm_is_accepted(
+            "ssh-ed25519-cert-v01@openssh.com",
+            &ed25519_only,
+        ));
+        assert!(!public_key_blob_algorithm_is_accepted(
+            "ssh-ed25519",
+            &ed25519_certificate_only,
+        ));
+        assert!(!public_key_blob_algorithm_is_accepted(
+            "ssh-rsa-cert-v01@openssh.com",
+            &rsa_only,
+        ));
+        assert!(!public_key_blob_algorithm_is_accepted(
+            "ssh-rsa",
+            &rsa_certificate_only,
+        ));
+        assert!(public_key_blob_algorithm_is_accepted(
+            "ssh-rsa-cert-v01@openssh.com",
+            &rsa_certificate_only,
+        ));
+    }
+
+    #[test]
+    fn should_normalize_rsa_certificate_signature_algorithms() {
+        let configured = vec![
+            "ssh-ed25519-cert-v01@openssh.com".to_string(),
+            "rsa-sha2-512-cert-v01@openssh.com".to_string(),
+            "rsa-sha2-256-cert-v01@openssh.com".to_string(),
+            "ssh-rsa-cert-v01@openssh.com".to_string(),
+        ];
+
+        assert_eq!(
+            libssh2_signature_algorithms(&configured),
+            "ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-256,ssh-rsa"
+        );
+    }
+
+    #[test]
+    fn should_inspect_legacy_pem_private_key_algorithm() {
+        let rsa = openssl::rsa::Rsa::generate(2048).expect("failed to generate RSA key");
+        let pem = rsa
+            .private_key_to_pem()
+            .expect("failed to encode RSA key as PEM");
+        let mut key_file = NamedTempFile::new().expect("failed to create private key file");
+        key_file
+            .write_all(&pem)
+            .expect("failed to write PEM private key");
+
+        let algorithm = private_key_algorithm(key_file.path(), None)
+            .expect("failed to inspect legacy PEM private key");
+        assert!(matches!(algorithm, ssh_key::Algorithm::Rsa { .. }));
+    }
 
     #[test]
     fn should_connect_with_identity_file_from_ssh_config() {
@@ -906,6 +1169,35 @@ mod test {
 
         let session = LibSsh2Session::connect(&opts)
             .expect("failed to fall back to the second configured IdentityFile");
+        assert!(
+            session
+                .authenticated()
+                .expect("failed to query session state")
+        );
+    }
+
+    #[test]
+    fn should_apply_pubkey_accepted_algorithms_from_ssh_config() {
+        let container = crate::ssh::container::OpensshServer::start();
+        let key_file = ssh_mock::create_key_file();
+        let legacy_config = ssh_mock::create_ssh_config_with_identity_and_pubkey_algorithms(
+            container.port(),
+            key_file.path(),
+            "ssh-rsa",
+        );
+        let opts =
+            SshOpts::new("sftp").config_file(legacy_config.path(), ParseRule::ALLOW_UNKNOWN_FIELDS);
+        assert!(LibSsh2Session::connect(&opts).is_err());
+
+        let modern_config = ssh_mock::create_ssh_config_with_identity_and_pubkey_algorithms(
+            container.port(),
+            key_file.path(),
+            "rsa-sha2-256",
+        );
+        let opts =
+            SshOpts::new("sftp").config_file(modern_config.path(), ParseRule::ALLOW_UNKNOWN_FIELDS);
+        let session = LibSsh2Session::connect(&opts)
+            .expect("failed to authenticate with the accepted RSA SHA-2 algorithm");
         assert!(
             session
                 .authenticated()

--- a/src/ssh/backend/libssh2.rs
+++ b/src/ssh/backend/libssh2.rs
@@ -14,12 +14,19 @@ use ssh2::{FileStat, OpenType, RenameFlags};
 
 use super::{SshSession, interface, socket};
 use crate::ssh::backend::Sftp;
+use crate::ssh::backend::keepalive::ServerKeepalive;
 use crate::ssh::config::Config;
 use crate::{SshAgentIdentity, SshOpts};
 
 /// An implementation of [`SshSession`] using libssh2 as the backend.
 pub struct LibSsh2Session {
+    server_keepalives: Vec<ServerKeepalive>,
     session: ssh2::Session,
+}
+
+struct LibSsh2Transport {
+    session: ssh2::Session,
+    socket: TcpStream,
 }
 
 /// A wrapper around [`ssh2::Sftp`] to provide a SFTP client for [`LibSsh2Session`]
@@ -43,12 +50,29 @@ impl SshSession for LibSsh2Session {
     fn connect(opts: &SshOpts) -> RemoteResult<Self> {
         let ssh_config = Config::try_from(opts)?;
         debug!("Connecting to '{}'", ssh_config.address);
-        let mut session = connect_libssh2_transport(opts, &ssh_config)?;
-        authenticate_libssh2_session(&mut session, opts, &ssh_config)?;
-        Ok(Self { session })
+        let (mut transport, mut server_keepalives) = connect_libssh2_transport(opts, &ssh_config)?;
+        authenticate_libssh2_session(&mut transport.session, opts, &ssh_config)?;
+        if let Some(server_keepalive) = libssh2_server_keepalive(&transport, &ssh_config)? {
+            server_keepalives.push(server_keepalive);
+        }
+        // Stop the destination first, then each preceding jump host.
+        server_keepalives.reverse();
+        let session = transport.session;
+        Ok(Self {
+            session,
+            server_keepalives,
+        })
     }
 
     fn disconnect(&self) -> RemoteResult<()> {
+        let mut interrupted = false;
+        for server_keepalive in &self.server_keepalives {
+            interrupted |= server_keepalive.stop();
+        }
+        if interrupted {
+            let _ = self.session.disconnect(None, "Mandi!", None);
+            return Ok(());
+        }
         self.session
             .disconnect(None, "Mandi!", None)
             .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))
@@ -142,28 +166,72 @@ impl SshSession for LibSsh2Session {
     }
 }
 
-fn connect_libssh2_transport(opts: &SshOpts, destination: &Config) -> RemoteResult<ssh2::Session> {
+fn connect_libssh2_transport(
+    opts: &SshOpts,
+    destination: &Config,
+) -> RemoteResult<(LibSsh2Transport, Vec<ServerKeepalive>)> {
     let proxy_jumps = destination.proxy_jump_configs(opts)?;
     let Some(first_jump) = proxy_jumps.first() else {
-        return connect_libssh2_direct(opts, destination);
+        return connect_libssh2_direct(opts, destination).map(|transport| (transport, Vec::new()));
     };
 
-    let mut session = connect_libssh2_direct(opts, first_jump)?;
-    authenticate_libssh2_session(&mut session, opts, first_jump)?;
+    let mut server_keepalives = Vec::new();
+    let mut transport = connect_libssh2_direct(opts, first_jump)?;
+    authenticate_libssh2_session(&mut transport.session, opts, first_jump)?;
+    if let Some(server_keepalive) = libssh2_server_keepalive(&transport, first_jump)? {
+        server_keepalives.push(server_keepalive);
+    }
     for next_hop in proxy_jumps
         .iter()
         .skip(1)
         .chain(std::iter::once(destination))
     {
-        session = connect_libssh2_through_jump(opts, &session, next_hop)?;
+        transport = connect_libssh2_through_jump(opts, &transport.session, next_hop)?;
         if !std::ptr::eq(next_hop, destination) {
-            authenticate_libssh2_session(&mut session, opts, next_hop)?;
+            authenticate_libssh2_session(&mut transport.session, opts, next_hop)?;
+            if let Some(server_keepalive) = libssh2_server_keepalive(&transport, next_hop)? {
+                server_keepalives.push(server_keepalive);
+            }
         }
     }
-    Ok(session)
+    Ok((transport, server_keepalives))
 }
 
-fn connect_libssh2_direct(opts: &SshOpts, config: &Config) -> RemoteResult<ssh2::Session> {
+fn libssh2_server_keepalive(
+    transport: &LibSsh2Transport,
+    config: &Config,
+) -> RemoteResult<Option<ServerKeepalive>> {
+    let Some(interval) = config
+        .params
+        .server_alive_interval
+        .filter(|interval| !interval.is_zero())
+    else {
+        return Ok(None);
+    };
+    transport
+        .session
+        .set_keepalive(true, interval.as_secs().min(u64::from(u32::MAX)) as u32);
+    let socket = transport
+        .socket
+        .try_clone()
+        .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
+    let session = transport.session.clone();
+    Ok(ServerKeepalive::spawn(
+        interval,
+        move || {
+            let _ = socket.shutdown(Shutdown::Both);
+        },
+        move || match session.keepalive_send() {
+            Ok(_) => true,
+            Err(err) => {
+                warn!("failed to send SSH server keepalive: {err}");
+                false
+            }
+        },
+    ))
+}
+
+fn connect_libssh2_direct(opts: &SshOpts, config: &Config) -> RemoteResult<LibSsh2Transport> {
     let socket_addresses: Vec<SocketAddr> = config
         .address
         .to_socket_addrs()
@@ -211,7 +279,7 @@ fn connect_libssh2_through_jump(
     opts: &SshOpts,
     jump_session: &ssh2::Session,
     target: &Config,
-) -> RemoteResult<ssh2::Session> {
+) -> RemoteResult<LibSsh2Transport> {
     let mut last_error = None;
     for attempt in 1..=target.connection_attempts.max(1) {
         let (stream, cancelled, relay) = match libssh2_tunnel_stream(
@@ -254,7 +322,10 @@ fn connect_libssh2_stream(
     opts: &SshOpts,
     config: &Config,
     stream: TcpStream,
-) -> RemoteResult<ssh2::Session> {
+) -> RemoteResult<LibSsh2Transport> {
+    let socket = stream
+        .try_clone()
+        .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
     let mut session = ssh2::Session::new()
         .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
     session.set_timeout(config.connection_timeout.as_millis().min(u32::MAX.into()) as u32);
@@ -264,7 +335,7 @@ fn connect_libssh2_stream(
         error!("SSH handshake failed: {err}");
         RemoteError::new_ex(RemoteErrorType::ProtocolError, err)
     })?;
-    Ok(session)
+    Ok(LibSsh2Transport { session, socket })
 }
 
 fn authenticate_libssh2_session(
@@ -1470,6 +1541,7 @@ mod test {
                 .authenticated()
                 .expect("failed to query session state")
         );
+        assert_eq!(session.server_keepalives.len(), 2);
         assert_eq!(
             session.cmd("pwd").expect("command through proxy failed").0,
             0
@@ -1640,6 +1712,27 @@ mod test {
                 .expect("failed to read default SO_KEEPALIVE")
         );
         session.disconnect().expect("failed to disconnect");
+    }
+
+    #[test]
+    fn should_apply_configured_server_alive_interval() {
+        let container = crate::ssh::container::OpensshServer::start();
+        let port = container.port();
+        for (interval, enabled) in [(2, true), (0, false)] {
+            let mut config_file = NamedTempFile::new().expect("failed to create SSH config");
+            writeln!(
+                config_file,
+                "Host keepalive\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    ServerAliveInterval {interval}"
+            )
+            .expect("failed to write SSH config");
+            let opts = SshOpts::new("keepalive")
+                .config_file(config_file.path(), ParseRule::STRICT)
+                .password("password");
+            let session = LibSsh2Session::connect(&opts).expect("failed to connect");
+
+            assert_eq!(!session.server_keepalives.is_empty(), enabled);
+            session.disconnect().expect("failed to disconnect");
+        }
     }
 
     #[test]

--- a/src/ssh/backend/libssh2.rs
+++ b/src/ssh/backend/libssh2.rs
@@ -1,7 +1,9 @@
 use std::io::{Read, Seek, Write};
-use std::net::{SocketAddr, TcpStream, ToSocketAddrs as _};
+use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream, ToSocketAddrs as _};
 use std::path::{Path, PathBuf};
 use std::str::FromStr as _;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime};
 
 use remotefs::fs::stream::{ReadAndSeek, WriteAndSeek};
@@ -39,157 +41,10 @@ impl SshSession for LibSsh2Session {
     type Sftp = LibSsh2Sftp;
 
     fn connect(opts: &SshOpts) -> RemoteResult<Self> {
-        // parse configuration
         let ssh_config = Config::try_from(opts)?;
-        // Resolve host
         debug!("Connecting to '{}'", ssh_config.address);
-        // setup tcp stream
-        let socket_addresses: Vec<SocketAddr> = match ssh_config.address.to_socket_addrs() {
-            Ok(s) => s.collect(),
-            Err(err) => {
-                return Err(RemoteError::new_ex(
-                    RemoteErrorType::BadAddress,
-                    err.to_string(),
-                ));
-            }
-        };
-        let mut stream = None;
-        let mut last_connection_error = None;
-        for _ in 0..ssh_config.connection_attempts {
-            for socket_addr in socket_addresses.iter() {
-                trace!(
-                    "Trying to connect to socket address '{}' (timeout: {}s)",
-                    socket_addr,
-                    ssh_config.connection_timeout.as_secs()
-                );
-                match tcp_connect(
-                    socket_addr,
-                    ssh_config.connection_timeout,
-                    ssh_config.params.bind_address.as_deref(),
-                    ssh_config.params.bind_interface.as_deref(),
-                ) {
-                    Ok(tcp_stream) => {
-                        debug!("Connection established with address {socket_addr}");
-                        stream = Some(tcp_stream);
-                        break;
-                    }
-                    Err(err) => last_connection_error = Some(err),
-                }
-            }
-            // break from attempts cycle if some
-            if stream.is_some() {
-                break;
-            }
-        }
-        // If stream is None, return connection timeout
-        let stream = match stream {
-            Some(s) => s,
-            None => {
-                let message = last_connection_error.map_or_else(
-                    || "No suitable socket address found; connection timeout".to_string(),
-                    |err| err.to_string(),
-                );
-                error!("Could not establish connection: {message}");
-                return Err(RemoteError::new_ex(
-                    RemoteErrorType::ConnectionError,
-                    message,
-                ));
-            }
-        };
-        socket::set_keepalive(&stream, ssh_config.params.tcp_keep_alive.unwrap_or(true))
-            .map_err(|e| RemoteError::new_ex(RemoteErrorType::ConnectionError, e))?;
-        // Create session
-        let mut session = match ssh2::Session::new() {
-            Ok(s) => s,
-            Err(err) => {
-                error!("Could not create session: {err}");
-                return Err(RemoteError::new_ex(RemoteErrorType::ConnectionError, err));
-            }
-        };
-        // Set TCP stream
-        session.set_tcp_stream(stream);
-        // configure algos
-        set_algo_prefs(&mut session, opts, &ssh_config)?;
-        // Open connection and initialize handshake
-        if let Err(err) = session.handshake() {
-            error!("SSH handshake failed: {err}");
-            return Err(RemoteError::new_ex(RemoteErrorType::ProtocolError, err));
-        }
-
-        let pubkey_authentication = ssh_config.params.pubkey_authentication.unwrap_or(true);
-
-        // if use_ssh_agent is enabled, try to authenticate with ssh agent
-        if pubkey_authentication && let Some(ssh_agent_config) = &opts.ssh_agent_identity {
-            match session_auth_with_agent(
-                &mut session,
-                &ssh_config.username,
-                ssh_agent_config,
-                ssh_config.params.pubkey_accepted_algorithms.algorithms(),
-            ) {
-                Ok(_) => {
-                    info!("Authenticated with ssh agent");
-                    return Ok(Self { session });
-                }
-                Err(err) => {
-                    error!("Could not authenticate with ssh agent: {err}");
-                }
-            }
-        }
-
-        // Authenticate with password or key
-        if !session.authenticated() {
-            let mut methods = vec![];
-            // first try with ssh agent
-            if pubkey_authentication {
-                if let Some(rsa_key) = opts.key_storage.as_ref().and_then(|x| {
-                    x.resolve(ssh_config.host.as_str(), ssh_config.username.as_str())
-                        .or(x.resolve(
-                            ssh_config.resolved_host.as_str(),
-                            ssh_config.username.as_str(),
-                        ))
-                }) {
-                    methods.push(Authentication::RsaKey {
-                        private_key: rsa_key.clone(),
-                        certificate: ssh_config.params.certificate_file.clone(),
-                    });
-                }
-                if let Some(identity_files) = ssh_config.params.identity_file.as_deref() {
-                    methods.extend(identity_files.iter().cloned().map(|private_key| {
-                        Authentication::RsaKey {
-                            private_key,
-                            certificate: ssh_config.params.certificate_file.clone(),
-                        }
-                    }));
-                }
-            }
-            // then try with password
-            if let Some(password) = opts.password.as_ref() {
-                methods.push(Authentication::Password(password.clone()));
-            }
-
-            // try with methods
-            let mut last_err = None;
-            for auth_method in methods {
-                match session_auth(&mut session, opts, &ssh_config, auth_method) {
-                    Ok(_) => {
-                        info!("Authenticated successfully");
-                        return Ok(Self { session });
-                    }
-                    Err(err) => {
-                        error!("Authentication failed: {err}",);
-                        last_err = Some(err);
-                    }
-                }
-            }
-
-            return Err(last_err.unwrap_or_else(|| {
-                RemoteError::new_ex(
-                    RemoteErrorType::AuthenticationFailed,
-                    "no authentication method provided",
-                )
-            }));
-        }
-
+        let mut session = connect_libssh2_transport(opts, &ssh_config)?;
+        authenticate_libssh2_session(&mut session, opts, &ssh_config)?;
         Ok(Self { session })
     }
 
@@ -284,6 +139,293 @@ impl SshSession for LibSsh2Session {
                 )
             })?,
         })
+    }
+}
+
+fn connect_libssh2_transport(opts: &SshOpts, destination: &Config) -> RemoteResult<ssh2::Session> {
+    let proxy_jumps = destination.proxy_jump_configs(opts)?;
+    let Some(first_jump) = proxy_jumps.first() else {
+        return connect_libssh2_direct(opts, destination);
+    };
+
+    let mut session = connect_libssh2_direct(opts, first_jump)?;
+    authenticate_libssh2_session(&mut session, opts, first_jump)?;
+    for next_hop in proxy_jumps
+        .iter()
+        .skip(1)
+        .chain(std::iter::once(destination))
+    {
+        session = connect_libssh2_through_jump(opts, &session, next_hop)?;
+        if !std::ptr::eq(next_hop, destination) {
+            authenticate_libssh2_session(&mut session, opts, next_hop)?;
+        }
+    }
+    Ok(session)
+}
+
+fn connect_libssh2_direct(opts: &SshOpts, config: &Config) -> RemoteResult<ssh2::Session> {
+    let socket_addresses: Vec<SocketAddr> = config
+        .address
+        .to_socket_addrs()
+        .map_err(|err| RemoteError::new_ex(RemoteErrorType::BadAddress, err))?
+        .collect();
+    let mut stream = None;
+    let mut last_connection_error = None;
+    for _ in 0..config.connection_attempts.max(1) {
+        for socket_addr in &socket_addresses {
+            trace!(
+                "Trying to connect to socket address '{}' (timeout: {}s)",
+                socket_addr,
+                config.connection_timeout.as_secs()
+            );
+            match tcp_connect(
+                socket_addr,
+                config.connection_timeout,
+                config.params.bind_address.as_deref(),
+                config.params.bind_interface.as_deref(),
+            ) {
+                Ok(tcp_stream) => {
+                    stream = Some(tcp_stream);
+                    break;
+                }
+                Err(err) => last_connection_error = Some(err),
+            }
+        }
+        if stream.is_some() {
+            break;
+        }
+    }
+    let stream = stream.ok_or_else(|| {
+        let message = last_connection_error.map_or_else(
+            || "No suitable socket address found; connection timeout".to_string(),
+            |err| err.to_string(),
+        );
+        RemoteError::new_ex(RemoteErrorType::ConnectionError, message)
+    })?;
+    socket::set_keepalive(&stream, config.params.tcp_keep_alive.unwrap_or(true))
+        .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
+    connect_libssh2_stream(opts, config, stream)
+}
+
+fn connect_libssh2_through_jump(
+    opts: &SshOpts,
+    jump_session: &ssh2::Session,
+    target: &Config,
+) -> RemoteResult<ssh2::Session> {
+    let mut last_error = None;
+    for attempt in 1..=target.connection_attempts.max(1) {
+        let (stream, cancelled, relay) = match libssh2_tunnel_stream(
+            jump_session,
+            &target.resolved_host,
+            target.port,
+            target.connection_timeout,
+        ) {
+            Ok(tunnel) => tunnel,
+            Err(err) if attempt < target.connection_attempts.max(1) => {
+                warn!("SSH connection attempt {attempt} through ProxyJump failed: {err}");
+                last_error = Some(err);
+                continue;
+            }
+            Err(err) => return Err(err),
+        };
+        let result = connect_libssh2_stream(opts, target, stream);
+        match result {
+            Ok(session) => {
+                drop(relay);
+                return Ok(session);
+            }
+            Err(err) if attempt < target.connection_attempts.max(1) => {
+                cancelled.store(true, Ordering::Release);
+                let _ = relay.join();
+                warn!("SSH connection attempt {attempt} through ProxyJump failed: {err}");
+                last_error = Some(err);
+            }
+            Err(err) => {
+                cancelled.store(true, Ordering::Release);
+                let _ = relay.join();
+                return Err(err);
+            }
+        }
+    }
+    Err(last_error.expect("at least one connection attempt"))
+}
+
+fn connect_libssh2_stream(
+    opts: &SshOpts,
+    config: &Config,
+    stream: TcpStream,
+) -> RemoteResult<ssh2::Session> {
+    let mut session = ssh2::Session::new()
+        .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
+    session.set_timeout(config.connection_timeout.as_millis().min(u32::MAX.into()) as u32);
+    session.set_tcp_stream(stream);
+    set_algo_prefs(&mut session, opts, config)?;
+    session.handshake().map_err(|err| {
+        error!("SSH handshake failed: {err}");
+        RemoteError::new_ex(RemoteErrorType::ProtocolError, err)
+    })?;
+    Ok(session)
+}
+
+fn authenticate_libssh2_session(
+    session: &mut ssh2::Session,
+    opts: &SshOpts,
+    config: &Config,
+) -> RemoteResult<()> {
+    let pubkey_authentication = config.params.pubkey_authentication.unwrap_or(true);
+    if pubkey_authentication && let Some(agent_identity) = &opts.ssh_agent_identity {
+        match session_auth_with_agent(
+            session,
+            &config.username,
+            agent_identity,
+            config.params.pubkey_accepted_algorithms.algorithms(),
+        ) {
+            Ok(()) => return Ok(()),
+            Err(err) => error!("Could not authenticate with ssh agent: {err}"),
+        }
+    }
+
+    let mut methods = Vec::new();
+    if pubkey_authentication {
+        if let Some(private_key) = opts.key_storage.as_ref().and_then(|storage| {
+            storage
+                .resolve(&config.host, &config.username)
+                .or_else(|| storage.resolve(&config.resolved_host, &config.username))
+        }) {
+            methods.push(Authentication::RsaKey {
+                private_key,
+                certificate: config.params.certificate_file.clone(),
+            });
+        }
+        if let Some(identity_files) = config.params.identity_file.as_deref() {
+            methods.extend(identity_files.iter().cloned().map(|private_key| {
+                Authentication::RsaKey {
+                    private_key,
+                    certificate: config.params.certificate_file.clone(),
+                }
+            }));
+        }
+    }
+    if let Some(password) = opts.password.as_ref() {
+        methods.push(Authentication::Password(password.clone()));
+    }
+
+    let mut last_error = None;
+    for method in methods {
+        match session_auth(session, opts, config, method) {
+            Ok(()) => return Ok(()),
+            Err(err) => last_error = Some(err),
+        }
+    }
+    Err(last_error.unwrap_or_else(|| {
+        RemoteError::new_ex(
+            RemoteErrorType::AuthenticationFailed,
+            "no authentication method provided",
+        )
+    }))
+}
+
+fn libssh2_tunnel_stream(
+    session: &ssh2::Session,
+    target_host: &str,
+    target_port: u16,
+    timeout: Duration,
+) -> RemoteResult<(TcpStream, Arc<AtomicBool>, std::thread::JoinHandle<()>)> {
+    session.set_blocking(true);
+    session.set_timeout(timeout.as_millis().min(u32::MAX.into()) as u32);
+    let channel = session.channel_direct_tcpip(target_host, target_port, None);
+    session.set_blocking(false);
+    let channel =
+        channel.map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
+    let listener = TcpListener::bind(("127.0.0.1", 0))
+        .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
+    let client = TcpStream::connect(
+        listener
+            .local_addr()
+            .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?,
+    )
+    .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
+    let (relay, _) = listener
+        .accept()
+        .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))?;
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let relay_cancelled = Arc::clone(&cancelled);
+    let relay = std::thread::spawn(move || {
+        relay_libssh2_channel(channel, relay, &relay_cancelled);
+    });
+    Ok((client, cancelled, relay))
+}
+
+fn relay_libssh2_channel(
+    mut channel: ssh2::Channel,
+    mut socket: TcpStream,
+    cancelled: &AtomicBool,
+) {
+    let _ = socket.set_nonblocking(true);
+    let mut socket_eof = false;
+    let mut channel_eof = false;
+    let mut channel_eof_sent = false;
+    let mut to_channel = Vec::new();
+    let mut to_socket = Vec::new();
+    let mut buffer = [0_u8; 32 * 1024];
+
+    while !cancelled.load(Ordering::Acquire) {
+        let mut progressed = false;
+        if !socket_eof && to_channel.is_empty() {
+            match socket.read(&mut buffer) {
+                Ok(0) => socket_eof = true,
+                Ok(read) => {
+                    to_channel.extend_from_slice(&buffer[..read]);
+                    progressed = true;
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(_) => break,
+            }
+        }
+        if !to_channel.is_empty() {
+            match channel.write(&to_channel) {
+                Ok(written) => {
+                    to_channel.drain(..written);
+                    progressed = written > 0;
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(_) => break,
+            }
+        }
+        if socket_eof && to_channel.is_empty() && !channel_eof_sent {
+            channel_eof_sent = channel.send_eof().is_ok();
+        }
+
+        if !channel_eof && to_socket.is_empty() {
+            match channel.read(&mut buffer) {
+                Ok(0) => channel_eof = true,
+                Ok(read) => {
+                    to_socket.extend_from_slice(&buffer[..read]);
+                    progressed = true;
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(_) => break,
+            }
+        }
+        if !to_socket.is_empty() {
+            match socket.write(&to_socket) {
+                Ok(written) => {
+                    to_socket.drain(..written);
+                    progressed = written > 0;
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(_) => break,
+            }
+        }
+        if channel_eof && to_socket.is_empty() {
+            let _ = socket.shutdown(Shutdown::Write);
+            if socket_eof {
+                break;
+            }
+        }
+        if !progressed {
+            std::thread::sleep(Duration::from_millis(1));
+        }
     }
 }
 
@@ -1304,6 +1446,34 @@ mod test {
             .key_storage(Box::new(ssh_mock::MockSshKeyStorage::default()));
         let session = LibSsh2Session::connect(&opts).unwrap();
         assert!(session.authenticated().unwrap());
+    }
+
+    #[test]
+    fn should_connect_through_proxy_jump() {
+        use crate::ssh::container::ProxyJumpServers;
+
+        let servers = ProxyJumpServers::start();
+        let config_file = ssh_mock::create_ssh_config_with_proxy_jump(
+            &servers.target_host,
+            2222,
+            servers.first_jump.port(),
+            &servers.second_jump_host,
+        );
+        let opts = SshOpts::new("target")
+            .config_file(config_file.path(), ParseRule::ALLOW_UNKNOWN_FIELDS)
+            .password("password");
+
+        let mut session =
+            LibSsh2Session::connect(&opts).expect("failed to connect through ProxyJump");
+        assert!(
+            session
+                .authenticated()
+                .expect("failed to query session state")
+        );
+        assert_eq!(
+            session.cmd("pwd").expect("command through proxy failed").0,
+            0
+        );
     }
 
     #[test]

--- a/src/ssh/backend/libssh2.rs
+++ b/src/ssh/backend/libssh2.rs
@@ -28,7 +28,10 @@ pub struct LibSsh2Sftp {
 /// Authentication method
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Authentication {
-    RsaKey(PathBuf),
+    RsaKey {
+        private_key: PathBuf,
+        certificate: Option<PathBuf>,
+    },
     Password(String),
 }
 
@@ -145,10 +148,18 @@ impl SshSession for LibSsh2Session {
                             ssh_config.username.as_str(),
                         ))
                 }) {
-                    methods.push(Authentication::RsaKey(rsa_key.clone()));
+                    methods.push(Authentication::RsaKey {
+                        private_key: rsa_key.clone(),
+                        certificate: ssh_config.params.certificate_file.clone(),
+                    });
                 }
                 if let Some(identity_files) = ssh_config.params.identity_file.as_deref() {
-                    methods.extend(identity_files.iter().cloned().map(Authentication::RsaKey));
+                    methods.extend(identity_files.iter().cloned().map(|private_key| {
+                        Authentication::RsaKey {
+                            private_key,
+                            certificate: ssh_config.params.certificate_file.clone(),
+                        }
+                    }));
                 }
             }
             // then try with password
@@ -815,15 +826,40 @@ fn session_auth_with_rsakey(
     session: &mut ssh2::Session,
     username: &str,
     private_key: &Path,
+    certificate: Option<&Path>,
     password: Option<&str>,
     accepted_algorithms: &[String],
 ) -> RemoteResult<()> {
-    let private_key_algorithm = private_key_algorithm(private_key, password)?;
-    if !pubkey_algorithm_is_accepted(&private_key_algorithm, accepted_algorithms) {
-        return Err(RemoteError::new_ex(
-            RemoteErrorType::AuthenticationFailed,
-            format!("private key algorithm {private_key_algorithm} is not accepted by SSH config"),
-        ));
+    if let Some(certificate) = certificate {
+        let certificate_algorithm = ssh_key::Certificate::read_file(certificate)
+            .map(|certificate| certificate.algorithm().to_certificate_type())
+            .map_err(|err| {
+                RemoteError::new_ex(
+                    RemoteErrorType::AuthenticationFailed,
+                    format!(
+                        "could not inspect certificate at '{}': {err}",
+                        certificate.display()
+                    ),
+                )
+            })?;
+        if !public_key_blob_algorithm_is_accepted(&certificate_algorithm, accepted_algorithms) {
+            return Err(RemoteError::new_ex(
+                RemoteErrorType::AuthenticationFailed,
+                format!(
+                    "certificate algorithm {certificate_algorithm} is not accepted by SSH config"
+                ),
+            ));
+        }
+    } else {
+        let private_key_algorithm = private_key_algorithm(private_key, password)?;
+        if !pubkey_algorithm_is_accepted(&private_key_algorithm, accepted_algorithms) {
+            return Err(RemoteError::new_ex(
+                RemoteErrorType::AuthenticationFailed,
+                format!(
+                    "private key algorithm {private_key_algorithm} is not accepted by SSH config"
+                ),
+            ));
+        }
     }
 
     debug!("Authenticating with username '{username}' and RSA key");
@@ -832,7 +868,7 @@ fn session_auth_with_rsakey(
         private_key.display()
     );
     session
-        .userauth_pubkey_file(username, None, private_key, password)
+        .userauth_pubkey_file(username, certificate, private_key, password)
         .map(|()| debug!("Authenticated with key at '{}'", private_key.display()))
         .map_err(|err| {
             error!("Authentication failed: {err}");
@@ -848,10 +884,14 @@ fn session_auth(
     authentication: Authentication,
 ) -> RemoteResult<()> {
     match authentication {
-        Authentication::RsaKey(private_key) => session_auth_with_rsakey(
+        Authentication::RsaKey {
+            private_key,
+            certificate,
+        } => session_auth_with_rsakey(
             session,
             &ssh_config.username,
             private_key.as_path(),
+            certificate.as_deref(),
             opts.password.as_deref(),
             ssh_config.params.pubkey_accepted_algorithms.algorithms(),
         ),
@@ -1116,6 +1156,29 @@ mod test {
 
         let session = LibSsh2Session::connect(&opts)
             .expect("failed to authenticate with IdentityFile from SSH config");
+        assert!(
+            session
+                .authenticated()
+                .expect("failed to query session state")
+        );
+    }
+
+    #[test]
+    fn should_connect_with_certificate_file_from_ssh_config() {
+        let (key_file, certificate_file) = ssh_mock::create_certificate_key_files();
+        let container = crate::ssh::container::OpensshServer::start_with_public_key(
+            ssh_mock::MOCK_CERTIFICATE_AUTHORITY,
+        );
+        let config_file = ssh_mock::create_ssh_config_with_certificate(
+            container.port(),
+            key_file.path(),
+            certificate_file.path(),
+        );
+        let opts =
+            SshOpts::new("sftp").config_file(config_file.path(), ParseRule::ALLOW_UNKNOWN_FIELDS);
+
+        let session = LibSsh2Session::connect(&opts)
+            .expect("failed to authenticate with CertificateFile from SSH config");
         assert!(
             session
                 .authenticated()

--- a/src/ssh/backend/libssh2.rs
+++ b/src/ssh/backend/libssh2.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, SystemTime};
 use remotefs::fs::stream::{ReadAndSeek, WriteAndSeek};
 use remotefs::fs::{FileType, Metadata, ReadStream, UnixPex, WriteStream};
 use remotefs::{File, RemoteError, RemoteErrorType, RemoteResult};
+use socket2::{Domain, Protocol, Socket, Type};
 use ssh2::{FileStat, OpenType, RenameFlags};
 
 use super::SshSession;
@@ -50,6 +51,7 @@ impl SshSession for LibSsh2Session {
             }
         };
         let mut stream = None;
+        let mut last_connection_error = None;
         for _ in 0..ssh_config.connection_attempts {
             for socket_addr in socket_addresses.iter() {
                 trace!(
@@ -57,10 +59,17 @@ impl SshSession for LibSsh2Session {
                     socket_addr,
                     ssh_config.connection_timeout.as_secs()
                 );
-                if let Ok(tcp_stream) = tcp_connect(socket_addr, ssh_config.connection_timeout) {
-                    debug!("Connection established with address {socket_addr}");
-                    stream = Some(tcp_stream);
-                    break;
+                match tcp_connect(
+                    socket_addr,
+                    ssh_config.connection_timeout,
+                    ssh_config.params.bind_address.as_deref(),
+                ) {
+                    Ok(tcp_stream) => {
+                        debug!("Connection established with address {socket_addr}");
+                        stream = Some(tcp_stream);
+                        break;
+                    }
+                    Err(err) => last_connection_error = Some(err),
                 }
             }
             // break from attempts cycle if some
@@ -72,10 +81,14 @@ impl SshSession for LibSsh2Session {
         let stream = match stream {
             Some(s) => s,
             None => {
-                error!("No suitable socket address found; connection timeout");
+                let message = last_connection_error.map_or_else(
+                    || "No suitable socket address found; connection timeout".to_string(),
+                    |err| err.to_string(),
+                );
+                error!("Could not establish connection: {message}");
                 return Err(RemoteError::new_ex(
                     RemoteErrorType::ConnectionError,
-                    "connection timeout",
+                    message,
                 ));
             }
         };
@@ -574,12 +587,49 @@ fn perform_shell_cmd<S: AsRef<str>>(session: &mut ssh2::Session, cmd: S) -> Remo
 
 /// connect to socket address with provided timeout.
 /// If timeout is zero, don't set timeout
-fn tcp_connect(address: &SocketAddr, timeout: Duration) -> std::io::Result<TcpStream> {
-    if timeout.is_zero() {
-        TcpStream::connect(address)
-    } else {
-        TcpStream::connect_timeout(address, timeout)
+fn tcp_connect(
+    address: &SocketAddr,
+    timeout: Duration,
+    bind_address: Option<&str>,
+) -> std::io::Result<TcpStream> {
+    let Some(bind_address) = bind_address else {
+        return if timeout.is_zero() {
+            TcpStream::connect(address)
+        } else {
+            TcpStream::connect_timeout(address, timeout)
+        };
+    };
+
+    let mut last_error = None;
+    for source_address in (bind_address, 0)
+        .to_socket_addrs()?
+        .filter(|source| source.is_ipv4() == address.is_ipv4())
+    {
+        let result = (|| {
+            let socket = Socket::new(
+                Domain::for_address(*address),
+                Type::STREAM,
+                Some(Protocol::TCP),
+            )?;
+            socket.bind(&source_address.into())?;
+            if timeout.is_zero() {
+                socket.connect(&(*address).into())?;
+            } else {
+                socket.connect_timeout(&(*address).into(), timeout)?;
+            }
+            Ok::<TcpStream, std::io::Error>(socket.into())
+        })();
+        match result {
+            Ok(stream) => return Ok(stream),
+            Err(err) => last_error = Some(err),
+        }
     }
+    Err(last_error.unwrap_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::AddrNotAvailable,
+            format!("no {address} address family found for BindAddress {bind_address}"),
+        )
+    }))
 }
 
 /// Configure algorithm preferences into session
@@ -777,6 +827,7 @@ fn session_auth_with_password(
 mod test {
 
     use ssh2_config::ParseRule;
+    use tempfile::NamedTempFile;
 
     use super::*;
     use crate::mock::ssh as ssh_mock;
@@ -874,6 +925,35 @@ mod test {
             .port(port)
             .username("sftp")
             .password("ippopotamo");
+        assert!(LibSsh2Session::connect(&opts).is_err());
+    }
+
+    #[test]
+    fn should_apply_configured_bind_address() {
+        let container = crate::ssh::container::OpensshServer::start();
+        let port = container.port();
+        let mut valid_config = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            valid_config,
+            "Host bound\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    BindAddress 127.0.0.1"
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("bound")
+            .config_file(valid_config.path(), ParseRule::STRICT)
+            .password("password");
+        let session = LibSsh2Session::connect(&opts)
+            .expect("failed to connect with an available bind address");
+        session.disconnect().expect("failed to disconnect");
+
+        let mut invalid_config = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            invalid_config,
+            "Host bound\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    BindAddress 192.0.2.1"
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("bound")
+            .config_file(invalid_config.path(), ParseRule::STRICT)
+            .password("password");
         assert!(LibSsh2Session::connect(&opts).is_err());
     }
 

--- a/src/ssh/backend/libssh2.rs
+++ b/src/ssh/backend/libssh2.rs
@@ -139,6 +139,9 @@ impl SshSession for LibSsh2Session {
             }) {
                 methods.push(Authentication::RsaKey(rsa_key.clone()));
             }
+            if let Some(identity_files) = ssh_config.params.identity_file.as_deref() {
+                methods.extend(identity_files.iter().cloned().map(Authentication::RsaKey));
+            }
             // then try with password
             if let Some(password) = opts.password.as_ref() {
                 methods.push(Authentication::Password(password.clone()));
@@ -772,31 +775,19 @@ fn session_auth_with_rsakey(
     username: &str,
     private_key: &Path,
     password: Option<&str>,
-    identity_file: Option<&[PathBuf]>,
 ) -> RemoteResult<()> {
     debug!("Authenticating with username '{username}' and RSA key");
-    let mut keys = vec![private_key];
-    if let Some(identity_file) = identity_file {
-        let other_keys: Vec<&Path> = identity_file.iter().map(|x| x.as_path()).collect();
-        keys.extend(other_keys);
-    }
-    // iterate over keys
-    for key in keys.into_iter() {
-        trace!("Trying to authenticate with RSA key at '{}'", key.display());
-        match session.userauth_pubkey_file(username, None, key, password) {
-            Ok(_) => {
-                debug!("Authenticated with key at '{}'", key.display());
-                return Ok(());
-            }
-            Err(err) => {
-                error!("Authentication failed: {err}");
-            }
-        }
-    }
-    Err(RemoteError::new_ex(
-        RemoteErrorType::AuthenticationFailed,
-        "could not find any suitable RSA key to authenticate with",
-    ))
+    trace!(
+        "Trying to authenticate with RSA key at '{}'",
+        private_key.display()
+    );
+    session
+        .userauth_pubkey_file(username, None, private_key, password)
+        .map(|()| debug!("Authenticated with key at '{}'", private_key.display()))
+        .map_err(|err| {
+            error!("Authentication failed: {err}");
+            RemoteError::new_ex(RemoteErrorType::AuthenticationFailed, err)
+        })
 }
 
 /// Authenticate on session with the provided [`Authentication`] method.
@@ -812,7 +803,6 @@ fn session_auth(
             &ssh_config.username,
             private_key.as_path(),
             opts.password.as_deref(),
-            ssh_config.params.identity_file.as_deref(),
         ),
         Authentication::Password(password) => {
             session_auth_with_password(session, &ssh_config.username, &password)
@@ -847,6 +837,51 @@ mod test {
 
     use super::*;
     use crate::mock::ssh as ssh_mock;
+
+    #[test]
+    fn should_connect_with_identity_file_from_ssh_config() {
+        let container = crate::ssh::container::OpensshServer::start();
+        let key_file = ssh_mock::create_key_file();
+        let config_file =
+            ssh_mock::create_ssh_config_with_identity(container.port(), key_file.path());
+        let opts =
+            SshOpts::new("sftp").config_file(config_file.path(), ParseRule::ALLOW_UNKNOWN_FIELDS);
+
+        let session = LibSsh2Session::connect(&opts)
+            .expect("failed to authenticate with IdentityFile from SSH config");
+        assert!(
+            session
+                .authenticated()
+                .expect("failed to query session state")
+        );
+    }
+
+    #[test]
+    fn should_try_each_identity_file_from_ssh_config() {
+        let container = crate::ssh::container::OpensshServer::start();
+        let key_file = ssh_mock::create_key_file();
+        let missing_key = key_file.path().with_extension("missing");
+        assert!(!missing_key.exists());
+        let mut config_file = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            config_file,
+            "Host sftp\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    IdentityFile {missing}\n    IdentityFile {valid}",
+            port = container.port(),
+            missing = missing_key.display(),
+            valid = key_file.path().display(),
+        )
+        .expect("failed to write SSH config");
+        let opts =
+            SshOpts::new("sftp").config_file(config_file.path(), ParseRule::ALLOW_UNKNOWN_FIELDS);
+
+        let session = LibSsh2Session::connect(&opts)
+            .expect("failed to fall back to the second configured IdentityFile");
+        assert!(
+            session
+                .authenticated()
+                .expect("failed to query session state")
+        );
+    }
 
     #[test]
     fn should_connect_to_ssh_server_auth_user_password() {

--- a/src/ssh/backend/libssh2.rs
+++ b/src/ssh/backend/libssh2.rs
@@ -113,8 +113,10 @@ impl SshSession for LibSsh2Session {
             return Err(RemoteError::new_ex(RemoteErrorType::ProtocolError, err));
         }
 
+        let pubkey_authentication = ssh_config.params.pubkey_authentication.unwrap_or(true);
+
         // if use_ssh_agent is enabled, try to authenticate with ssh agent
-        if let Some(ssh_agent_config) = &opts.ssh_agent_identity {
+        if pubkey_authentication && let Some(ssh_agent_config) = &opts.ssh_agent_identity {
             match session_auth_with_agent(&mut session, &ssh_config.username, ssh_agent_config) {
                 Ok(_) => {
                     info!("Authenticated with ssh agent");
@@ -130,17 +132,19 @@ impl SshSession for LibSsh2Session {
         if !session.authenticated() {
             let mut methods = vec![];
             // first try with ssh agent
-            if let Some(rsa_key) = opts.key_storage.as_ref().and_then(|x| {
-                x.resolve(ssh_config.host.as_str(), ssh_config.username.as_str())
-                    .or(x.resolve(
-                        ssh_config.resolved_host.as_str(),
-                        ssh_config.username.as_str(),
-                    ))
-            }) {
-                methods.push(Authentication::RsaKey(rsa_key.clone()));
-            }
-            if let Some(identity_files) = ssh_config.params.identity_file.as_deref() {
-                methods.extend(identity_files.iter().cloned().map(Authentication::RsaKey));
+            if pubkey_authentication {
+                if let Some(rsa_key) = opts.key_storage.as_ref().and_then(|x| {
+                    x.resolve(ssh_config.host.as_str(), ssh_config.username.as_str())
+                        .or(x.resolve(
+                            ssh_config.resolved_host.as_str(),
+                            ssh_config.username.as_str(),
+                        ))
+                }) {
+                    methods.push(Authentication::RsaKey(rsa_key.clone()));
+                }
+                if let Some(identity_files) = ssh_config.params.identity_file.as_deref() {
+                    methods.extend(identity_files.iter().cloned().map(Authentication::RsaKey));
+                }
             }
             // then try with password
             if let Some(password) = opts.password.as_ref() {
@@ -849,6 +853,32 @@ mod test {
 
         let session = LibSsh2Session::connect(&opts)
             .expect("failed to authenticate with IdentityFile from SSH config");
+        assert!(
+            session
+                .authenticated()
+                .expect("failed to query session state")
+        );
+    }
+
+    #[test]
+    fn should_disable_public_key_authentication_from_ssh_config() {
+        let container = crate::ssh::container::OpensshServer::start();
+        let key_file = ssh_mock::create_key_file();
+        let config_file = ssh_mock::create_ssh_config_with_identity_and_pubkey_authentication(
+            container.port(),
+            key_file.path(),
+            false,
+        );
+        let opts =
+            SshOpts::new("sftp").config_file(config_file.path(), ParseRule::ALLOW_UNKNOWN_FIELDS);
+
+        assert!(LibSsh2Session::connect(&opts).is_err());
+
+        let opts = SshOpts::new("sftp")
+            .config_file(config_file.path(), ParseRule::ALLOW_UNKNOWN_FIELDS)
+            .password("password");
+        let session =
+            LibSsh2Session::connect(&opts).expect("password authentication should remain enabled");
         assert!(
             session
                 .authenticated()

--- a/src/ssh/backend/libssh2.rs
+++ b/src/ssh/backend/libssh2.rs
@@ -10,7 +10,7 @@ use remotefs::{File, RemoteError, RemoteErrorType, RemoteResult};
 use socket2::{Domain, Protocol, Socket, Type};
 use ssh2::{FileStat, OpenType, RenameFlags};
 
-use super::{SshSession, interface};
+use super::{SshSession, interface, socket};
 use crate::ssh::backend::Sftp;
 use crate::ssh::config::Config;
 use crate::{SshAgentIdentity, SshOpts};
@@ -93,6 +93,8 @@ impl SshSession for LibSsh2Session {
                 ));
             }
         };
+        socket::set_keepalive(&stream, ssh_config.params.tcp_keep_alive.unwrap_or(true))
+            .map_err(|e| RemoteError::new_ex(RemoteErrorType::ConnectionError, e))?;
         // Create session
         let mut session = match ssh2::Session::new() {
             Ok(s) => s,
@@ -1012,6 +1014,42 @@ mod test {
             .config_file(invalid_config.path(), ParseRule::STRICT)
             .password("password");
         assert!(LibSsh2Session::connect(&opts).is_err());
+    }
+
+    #[test]
+    fn should_apply_configured_tcp_keep_alive() {
+        let container = crate::ssh::container::OpensshServer::start();
+        let port = container.port();
+        for (configured, expected) in [("yes", true), ("no", false)] {
+            let mut config_file = NamedTempFile::new().expect("failed to create SSH config");
+            writeln!(
+                config_file,
+                "Host keepalive\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    TCPKeepAlive {configured}"
+            )
+            .expect("failed to write SSH config");
+            let opts = SshOpts::new("keepalive")
+                .config_file(config_file.path(), ParseRule::STRICT)
+                .password("password");
+            let session = LibSsh2Session::connect(&opts).expect("failed to connect");
+
+            assert_eq!(
+                crate::ssh::backend::socket::keepalive(&session.session)
+                    .expect("failed to read SO_KEEPALIVE"),
+                expected
+            );
+            session.disconnect().expect("failed to disconnect");
+        }
+
+        let opts = SshOpts::new("127.0.0.1")
+            .port(port)
+            .username("sftp")
+            .password("password");
+        let session = LibSsh2Session::connect(&opts).expect("failed to connect");
+        assert!(
+            crate::ssh::backend::socket::keepalive(&session.session)
+                .expect("failed to read default SO_KEEPALIVE")
+        );
+        session.disconnect().expect("failed to disconnect");
     }
 
     #[test]

--- a/src/ssh/backend/libssh2.rs
+++ b/src/ssh/backend/libssh2.rs
@@ -11,15 +11,22 @@ use remotefs::fs::{FileType, Metadata, ReadStream, UnixPex, WriteStream};
 use remotefs::{File, RemoteError, RemoteErrorType, RemoteResult};
 use socket2::{Domain, Protocol, Socket, Type};
 use ssh2::{FileStat, OpenType, RenameFlags};
+use ssh2_config::{RemoteForwardDestination, RemoteForwardListen};
 
 use super::{SshSession, interface, socket};
 use crate::ssh::backend::Sftp;
+use crate::ssh::backend::forward::{
+    ChannelIo, ForwardConnection, ForwardWorker, MAX_FORWARD_CONNECTIONS,
+    tcp_remote_forward_endpoint,
+};
 use crate::ssh::backend::keepalive::ServerKeepalive;
 use crate::ssh::config::Config;
 use crate::{SshAgentIdentity, SshOpts};
 
 /// An implementation of [`SshSession`] using libssh2 as the backend.
 pub struct LibSsh2Session {
+    remote_forward_ports: Vec<u16>,
+    remote_forward_worker: Option<ForwardWorker>,
     server_keepalives: Vec<ServerKeepalive>,
     session: ssh2::Session,
 }
@@ -57,14 +64,21 @@ impl SshSession for LibSsh2Session {
         }
         // Stop the destination first, then each preceding jump host.
         server_keepalives.reverse();
+        let (remote_forward_worker, remote_forward_ports) =
+            setup_libssh2_remote_forwards(opts, &ssh_config)?;
         let session = transport.session;
         Ok(Self {
             session,
+            remote_forward_ports,
+            remote_forward_worker,
             server_keepalives,
         })
     }
 
     fn disconnect(&self) -> RemoteResult<()> {
+        if let Some(worker) = &self.remote_forward_worker {
+            worker.stop();
+        }
         let mut interrupted = false;
         for server_keepalive in &self.server_keepalives {
             interrupted |= server_keepalive.stop();
@@ -76,6 +90,10 @@ impl SshSession for LibSsh2Session {
         self.session
             .disconnect(None, "Mandi!", None)
             .map_err(|err| RemoteError::new_ex(RemoteErrorType::ConnectionError, err))
+    }
+
+    fn remote_forward_ports(&self) -> &[u16] {
+        &self.remote_forward_ports
     }
 
     fn authenticated(&self) -> RemoteResult<bool> {
@@ -228,6 +246,185 @@ fn libssh2_server_keepalive(
                 false
             }
         },
+    ))
+}
+
+struct LibSsh2ForwardListener {
+    listener: ssh2::Listener,
+    destination: Option<RemoteForwardDestination>,
+    connect_timeout: Duration,
+}
+
+impl ChannelIo for ssh2::Channel {
+    fn read_channel(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        Read::read(self, buffer)
+    }
+
+    fn write_channel(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        Write::write(self, buffer)
+    }
+
+    fn is_eof(&self) -> bool {
+        ssh2::Channel::eof(self)
+    }
+
+    fn send_eof(&mut self) -> std::io::Result<()> {
+        ssh2::Channel::send_eof(self).map_err(Into::into)
+    }
+
+    fn close(&mut self) {
+        let _ = ssh2::Channel::close(self);
+    }
+}
+
+fn setup_libssh2_remote_forwards(
+    opts: &SshOpts,
+    config: &Config,
+) -> RemoteResult<(Option<ForwardWorker>, Vec<u16>)> {
+    if config.params.remote_forward.is_empty() {
+        return Ok((None, Vec::new()));
+    }
+    #[cfg(not(unix))]
+    if config.params.remote_forward.iter().any(|forward| {
+        matches!(
+            forward.destination,
+            Some(RemoteForwardDestination::UnixSocket(_))
+        )
+    }) {
+        return Err(RemoteError::new_ex(
+            RemoteErrorType::UnsupportedFeature,
+            "Unix socket RemoteForward destinations are unavailable on this platform",
+        ));
+    }
+    if let Some(forward) = config
+        .params
+        .remote_forward
+        .iter()
+        .find(|forward| matches!(forward.listen, RemoteForwardListen::UnixSocket(_)))
+    {
+        return Err(RemoteError::new_ex(
+            RemoteErrorType::UnsupportedFeature,
+            format!(
+                "libssh2 cannot create Unix socket RemoteForward listener {}",
+                forward.listen
+            ),
+        ));
+    }
+
+    let (mut transport, mut server_keepalives) = connect_libssh2_transport(opts, config)?;
+    authenticate_libssh2_session(&mut transport.session, opts, config)?;
+    if let Some(server_keepalive) = libssh2_server_keepalive(&transport, config)? {
+        server_keepalives.push(server_keepalive);
+    }
+    server_keepalives.reverse();
+    let mut listeners = Vec::new();
+    let mut remote_forward_ports = Vec::new();
+    for forward in &config.params.remote_forward {
+        let (host, port) = tcp_remote_forward_endpoint(&forward.listen)
+            .expect("Unix socket listeners were rejected above");
+        let (listener, actual_port) = transport
+            .session
+            .channel_forward_listen(port, host, None)
+            .map_err(|err| {
+                RemoteError::new_ex(
+                    RemoteErrorType::ProtocolError,
+                    format!(
+                        "Could not configure RemoteForward {}: {err}",
+                        forward.listen
+                    ),
+                )
+            })?;
+        debug!(
+            "RemoteForward {} listening on assigned port {actual_port}",
+            forward.listen
+        );
+        remote_forward_ports.push(actual_port);
+        listeners.push(LibSsh2ForwardListener {
+            listener,
+            destination: forward.destination.clone(),
+            connect_timeout: config.connection_timeout,
+        });
+    }
+
+    transport.session.set_blocking(false);
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let worker_cancelled = cancelled.clone();
+    let worker = std::thread::spawn(move || {
+        let server_keepalives = server_keepalives;
+        let mut listeners = listeners;
+        let mut connections = Vec::<ForwardConnection<ssh2::Channel>>::new();
+        while !worker_cancelled.load(Ordering::Acquire) {
+            let mut progressed = false;
+            for listener in &mut listeners {
+                while connections.len() < MAX_FORWARD_CONNECTIONS {
+                    match listener.listener.accept() {
+                        Ok(channel) => {
+                            let connection = match &listener.destination {
+                                Some(destination) => ForwardConnection::fixed(
+                                    channel,
+                                    destination,
+                                    listener.connect_timeout,
+                                    Arc::clone(&worker_cancelled),
+                                ),
+                                None => Ok(ForwardConnection::dynamic(
+                                    channel,
+                                    listener.connect_timeout,
+                                    Arc::clone(&worker_cancelled),
+                                )),
+                            };
+                            match connection {
+                                Ok(connection) => connections.push(connection),
+                                Err(err) => {
+                                    warn!("Could not queue RemoteForward destination: {err}");
+                                }
+                            }
+                            progressed = true;
+                        }
+                        Err(err) => {
+                            let io_error: std::io::Error = err.into();
+                            if io_error.kind() != std::io::ErrorKind::WouldBlock {
+                                warn!("Could not accept RemoteForward connection: {io_error}");
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+
+            let mut index = 0;
+            while index < connections.len() {
+                match connections[index].pump() {
+                    Ok((true, connection_progressed)) => {
+                        progressed |= connection_progressed;
+                        index += 1;
+                    }
+                    Ok((false, connection_progressed)) => {
+                        progressed |= connection_progressed;
+                        connections.swap_remove(index);
+                    }
+                    Err(err) => {
+                        warn!("RemoteForward connection failed: {err}");
+                        connections.swap_remove(index);
+                    }
+                }
+            }
+            if !progressed {
+                std::thread::sleep(Duration::from_millis(2));
+            }
+        }
+        drop(connections);
+        drop(listeners);
+        for server_keepalive in &server_keepalives {
+            let _ = server_keepalive.stop();
+        }
+        let _ = transport
+            .session
+            .disconnect(None, "RemoteForward stopped", None);
+        let _ = transport.socket.shutdown(Shutdown::Both);
+    });
+    Ok((
+        Some(ForwardWorker::new(cancelled, worker)),
+        remote_forward_ports,
     ))
 }
 
@@ -1733,6 +1930,76 @@ mod test {
             assert_eq!(!session.server_keepalives.is_empty(), enabled);
             session.disconnect().expect("failed to disconnect");
         }
+    }
+
+    #[test]
+    fn should_apply_configured_remote_forward() {
+        crate::mock::logger();
+        let container = crate::ssh::container::OpensshServer::start_with_tcp_forwarding();
+        let (destination_port, destination) = ssh_mock::start_tcp_echo_server();
+        let (dynamic_destination_port, dynamic_destination) = ssh_mock::start_tcp_echo_server();
+        let remote_port = 43001;
+        let mut config_file = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            config_file,
+            "Host forwarded\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    RemoteForward 127.0.0.1:{remote_port} 127.0.0.1:{destination_port}\n    RemoteForward 0",
+            port = container.port(),
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("forwarded")
+            .config_file(config_file.path(), ParseRule::STRICT)
+            .password("password");
+        let mut session = LibSsh2Session::connect(&opts).expect("failed to connect");
+        let dynamic_port = *session
+            .remote_forward_ports()
+            .get(1)
+            .expect("dynamic RemoteForward did not report its assigned port");
+
+        let (status, output) = session
+            .cmd(format!("printf ping | nc -w 5 127.0.0.1 {remote_port}"))
+            .expect("failed to use configured remote forward");
+        assert_eq!(status, 0, "remote forwarding command failed: {output}");
+        assert_eq!(output, "pong\n");
+        destination.join().expect("TCP echo server panicked");
+
+        let (status, output) = session
+            .cmd(ssh_mock::socks5_test_command(
+                dynamic_port,
+                dynamic_destination_port,
+            ))
+            .expect("failed to use dynamic RemoteForward");
+        assert_eq!(status, 0, "dynamic forwarding command failed: {output}");
+        assert_eq!(output, "pong\n");
+        dynamic_destination
+            .join()
+            .expect("dynamic TCP echo server panicked");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn should_apply_remote_forward_to_unix_socket() {
+        let container = crate::ssh::container::OpensshServer::start_with_tcp_forwarding();
+        let (_directory, destination_path, destination) = ssh_mock::start_unix_echo_server();
+        let remote_port = 43201;
+        let mut config_file = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            config_file,
+            "Host forwarded\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    RemoteForward 127.0.0.1:{remote_port} {destination}",
+            port = container.port(),
+            destination = destination_path.display(),
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("forwarded")
+            .config_file(config_file.path(), ParseRule::STRICT)
+            .password("password");
+        let mut session = LibSsh2Session::connect(&opts).expect("failed to connect");
+
+        let (status, output) = session
+            .cmd(format!("printf ping | nc -w 5 127.0.0.1 {remote_port}"))
+            .expect("failed to use Unix destination RemoteForward");
+        assert_eq!(status, 0, "remote forwarding command failed: {output}");
+        assert_eq!(output, "pong\n");
+        destination.join().expect("Unix echo server panicked");
     }
 
     #[test]

--- a/src/ssh/backend/libssh2.rs
+++ b/src/ssh/backend/libssh2.rs
@@ -13,11 +13,10 @@ use socket2::{Domain, Protocol, Socket, Type};
 use ssh2::{FileStat, OpenType, RenameFlags};
 use ssh2_config::{RemoteForwardDestination, RemoteForwardListen};
 
-use super::{SshSession, interface, socket};
+use super::{MAX_FORWARD_CONNECTIONS, SshSession, interface, socket};
 use crate::ssh::backend::Sftp;
 use crate::ssh::backend::forward::{
-    ChannelIo, ForwardConnection, ForwardWorker, MAX_FORWARD_CONNECTIONS,
-    tcp_remote_forward_endpoint,
+    ChannelIo, ForwardConnection, ForwardWorker, tcp_remote_forward_endpoint,
 };
 use crate::ssh::backend::keepalive::ServerKeepalive;
 use crate::ssh::config::Config;

--- a/src/ssh/backend/russh.rs
+++ b/src/ssh/backend/russh.rs
@@ -1452,6 +1452,30 @@ mod test {
     }
 
     #[test]
+    fn should_connect_with_certificate_file_from_ssh_config() {
+        use crate::ssh::container::OpensshServer;
+
+        let (key_file, certificate_file) = ssh_mock::create_certificate_key_files();
+        let container = OpensshServer::start_with_public_key(ssh_mock::MOCK_CERTIFICATE_AUTHORITY);
+        let config_file = ssh_mock::create_ssh_config_with_certificate(
+            container.port(),
+            key_file.path(),
+            certificate_file.path(),
+        );
+        let opts = SshOpts::new("sftp")
+            .config_file(config_file.path(), ParseRule::ALLOW_UNKNOWN_FIELDS)
+            .runtime(test_runtime());
+
+        let session = RusshSession::<NoCheckServerKey>::connect(&opts)
+            .expect("failed to authenticate with CertificateFile from SSH config");
+        assert!(
+            session
+                .authenticated()
+                .expect("failed to query session state")
+        );
+    }
+
+    #[test]
     fn should_apply_pubkey_accepted_algorithms_from_ssh_config() {
         use crate::ssh::container::OpensshServer;
 

--- a/src/ssh/backend/russh.rs
+++ b/src/ssh/backend/russh.rs
@@ -23,7 +23,7 @@ use tokio::net::{TcpSocket, TcpStream};
 use tokio::runtime::Runtime;
 use tokio::time::{Instant, Sleep};
 
-use super::{SshSession, WriteMode, interface};
+use super::{SshSession, WriteMode, interface, socket};
 use crate::SshOpts;
 use crate::ssh::backend::Sftp;
 use crate::ssh::config::Config;
@@ -149,6 +149,7 @@ fn connect_with_timeout<T>(
     address: &str,
     bind_address: Option<&str>,
     bind_interface: Option<&str>,
+    tcp_keep_alive: Option<bool>,
     timeout: std::time::Duration,
 ) -> RemoteResult<Handle<T>>
 where
@@ -157,8 +158,11 @@ where
     let deadline = Instant::now() + timeout;
     let stream = runtime
         .block_on(async {
-            tokio::time::timeout_at(deadline, connect_tcp(address, bind_address, bind_interface))
-                .await
+            tokio::time::timeout_at(
+                deadline,
+                connect_tcp(address, bind_address, bind_interface, tcp_keep_alive),
+            )
+            .await
         })
         .map_err(|err| {
             let msg = format!("SSH connection timed out: {err}");
@@ -194,9 +198,13 @@ async fn connect_tcp(
     address: &str,
     bind_address: Option<&str>,
     bind_interface: Option<&str>,
+    tcp_keep_alive: Option<bool>,
 ) -> std::io::Result<TcpStream> {
+    let tcp_keep_alive = tcp_keep_alive.unwrap_or(true);
     if bind_address.is_none() && bind_interface.is_none() {
-        return TcpStream::connect(address).await;
+        let stream = TcpStream::connect(address).await?;
+        socket::set_keepalive(&stream, tcp_keep_alive)?;
+        return Ok(stream);
     }
 
     let source_addresses = if let Some(bind_address) = bind_address {
@@ -227,6 +235,10 @@ async fn connect_tcp(
                     continue;
                 }
             };
+            if let Err(err) = socket.set_keepalive(tcp_keep_alive) {
+                last_error = Some(err);
+                continue;
+            }
             if let Err(err) = socket.bind(*source_address) {
                 last_error = Some(err);
                 continue;
@@ -285,6 +297,7 @@ where
                 &ssh_config.address,
                 ssh_config.params.bind_address.as_deref(),
                 ssh_config.params.bind_interface.as_deref(),
+                ssh_config.params.tcp_keep_alive,
                 ssh_config.connection_timeout,
             ) {
                 Ok(session) => break session,
@@ -1409,6 +1422,56 @@ mod test {
             .password("ippopotamo")
             .runtime(runtime);
         assert!(RusshSession::<NoCheckServerKey>::connect(&opts).is_err());
+    }
+
+    #[test]
+    fn should_apply_configured_tcp_keep_alive() {
+        for (configured, expected) in [(Some(true), true), (Some(false), false), (None, true)] {
+            let listener = std::net::TcpListener::bind(("127.0.0.1", 0))
+                .expect("failed to bind test listener");
+            let address = listener
+                .local_addr()
+                .expect("failed to read test listener address");
+            let server = std::thread::spawn(move || {
+                let (_stream, _peer) = listener.accept().expect("failed to accept connection");
+            });
+            let runtime = test_runtime();
+            let stream = runtime
+                .block_on(connect_tcp(&address.to_string(), None, None, configured))
+                .expect("failed to connect test socket");
+
+            assert_eq!(
+                crate::ssh::backend::socket::keepalive(&stream)
+                    .expect("failed to read SO_KEEPALIVE"),
+                expected
+            );
+            drop(stream);
+            server.join().expect("test server panicked");
+        }
+
+        let listener =
+            std::net::TcpListener::bind(("127.0.0.1", 0)).expect("failed to bind test listener");
+        let address = listener
+            .local_addr()
+            .expect("failed to read test listener address");
+        let server = std::thread::spawn(move || {
+            let (_stream, _peer) = listener.accept().expect("failed to accept connection");
+        });
+        let runtime = test_runtime();
+        let stream = runtime
+            .block_on(connect_tcp(
+                &address.to_string(),
+                Some("127.0.0.1"),
+                None,
+                Some(true),
+            ))
+            .expect("failed to connect bound test socket");
+        assert!(
+            crate::ssh::backend::socket::keepalive(&stream)
+                .expect("failed to read bound SO_KEEPALIVE")
+        );
+        drop(stream);
+        server.join().expect("test server panicked");
     }
 
     #[test]

--- a/src/ssh/backend/russh.rs
+++ b/src/ssh/backend/russh.rs
@@ -4,9 +4,13 @@ mod auth;
 mod scp;
 
 use std::borrow::Cow;
+use std::future::Future as _;
 use std::io::{Read, Seek, Write};
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::{Context, Poll};
 
 use remotefs::fs::{Metadata, ReadStream, WriteStream};
 use remotefs::{File, RemoteError, RemoteErrorType, RemoteResult};
@@ -14,7 +18,10 @@ use russh::client::{Handle, Handler};
 use russh::keys::{Algorithm, PublicKeyOrCertificate};
 use russh::{Disconnect, client};
 use russh_sftp::client::SftpSession;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::net::TcpStream;
 use tokio::runtime::Runtime;
+use tokio::time::{Instant, Sleep};
 
 use super::{SshSession, WriteMode};
 use crate::SshOpts;
@@ -57,6 +64,85 @@ pub struct RusshSftp {
     session: Arc<SftpSession>,
 }
 
+struct ConnectionDeadlineStream {
+    inner: TcpStream,
+    deadline: Pin<Box<Sleep>>,
+    deadline_active: Arc<AtomicBool>,
+}
+
+impl ConnectionDeadlineStream {
+    fn new(inner: TcpStream, deadline: Instant, deadline_active: Arc<AtomicBool>) -> Self {
+        Self {
+            inner,
+            deadline: Box::pin(tokio::time::sleep_until(deadline)),
+            deadline_active,
+        }
+    }
+
+    fn poll_timed_out(&mut self, context: &mut Context<'_>) -> bool {
+        self.deadline_active.load(Ordering::Acquire)
+            && self.deadline.as_mut().poll(context).is_ready()
+    }
+}
+
+impl AsyncRead for ConnectionDeadlineStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        if self.poll_timed_out(context) {
+            return Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "SSH connection timed out",
+            )));
+        }
+        Pin::new(&mut self.inner).poll_read(context, buffer)
+    }
+}
+
+impl AsyncWrite for ConnectionDeadlineStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+        buffer: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        if self.poll_timed_out(context) {
+            return Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "SSH connection timed out",
+            )));
+        }
+        Pin::new(&mut self.inner).poll_write(context, buffer)
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        if self.poll_timed_out(context) {
+            return Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "SSH connection timed out",
+            )));
+        }
+        Pin::new(&mut self.inner).poll_flush(context)
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        if self.poll_timed_out(context) {
+            return Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "SSH connection timed out",
+            )));
+        }
+        Pin::new(&mut self.inner).poll_shutdown(context)
+    }
+}
+
 impl<T> SshSession for RusshSession<T>
 where
     T: Handler + Default + Send + 'static,
@@ -74,10 +160,7 @@ where
         let ssh_config = Config::try_from(opts)?;
         debug!("Connecting to '{}'", ssh_config.address);
 
-        let mut config = client::Config {
-            inactivity_timeout: Some(ssh_config.connection_timeout),
-            ..Default::default()
-        };
+        let mut config = client::Config::default();
 
         // Apply algorithm preferences from ssh config
         apply_config_algo_prefs(&mut config, &ssh_config);
@@ -86,16 +169,40 @@ where
         apply_opts_algo_prefs(&mut config, opts);
 
         let config = Arc::new(config);
-
-        let mut session = runtime
+        let deadline = Instant::now() + ssh_config.connection_timeout;
+        let stream = runtime
             .block_on(async {
-                client::connect(config, ssh_config.address.as_str(), T::default()).await
+                tokio::time::timeout_at(deadline, TcpStream::connect(&ssh_config.address)).await
             })
             .map_err(|err| {
-                let msg = format!("SSH connection failed: {err:?}");
+                let msg = format!("SSH connection timed out: {err}");
+                error!("{msg}");
+                RemoteError::new_ex(RemoteErrorType::ConnectionError, msg)
+            })?
+            .map_err(|err| {
+                let msg = format!("SSH connection failed: {err}");
                 error!("{msg}");
                 RemoteError::new_ex(RemoteErrorType::ConnectionError, msg)
             })?;
+        if config.nodelay
+            && let Err(err) = stream.set_nodelay(true)
+        {
+            warn!("Failed to enable TCP_NODELAY: {err}");
+        }
+
+        let deadline_active = Arc::new(AtomicBool::new(true));
+        let connection_deadline_active = deadline_active.clone();
+        let session_result = runtime.block_on(async {
+            let stream =
+                ConnectionDeadlineStream::new(stream, deadline, connection_deadline_active);
+            client::connect_stream(config, stream, T::default()).await
+        });
+        deadline_active.store(false, Ordering::Release);
+        let mut session = session_result.map_err(|err| {
+            let msg = format!("SSH connection failed: {err:?}");
+            error!("{msg}");
+            RemoteError::new_ex(RemoteErrorType::ConnectionError, msg)
+        })?;
 
         // Authenticate
         auth::authenticate(&mut session, &runtime, opts, &ssh_config)?;
@@ -1000,8 +1107,10 @@ where
 mod test {
 
     use std::sync::Arc;
+    use std::time::{Duration, Instant};
 
     use ssh2_config::ParseRule;
+    use tempfile::NamedTempFile;
 
     use super::*;
     use crate::mock::ssh as ssh_mock;
@@ -1208,6 +1317,36 @@ mod test {
             .password("ippopotamo")
             .runtime(runtime);
         assert!(RusshSession::<NoCheckServerKey>::connect(&opts).is_err());
+    }
+
+    #[test]
+    fn should_apply_connection_timeout_to_handshake() {
+        let (port, server) = ssh_mock::start_unresponsive_server(Duration::from_secs(2));
+        let mut config_file = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            config_file,
+            "Host unresponsive\n    HostName 127.0.0.1\n    Port {port}\n    ConnectTimeout 5"
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("unresponsive")
+            .config_file(config_file.path(), ParseRule::STRICT)
+            .connection_timeout(Duration::from_millis(100))
+            .runtime(test_runtime());
+
+        let started = Instant::now();
+        let result = RusshSession::<NoCheckServerKey>::connect(&opts);
+        let elapsed = started.elapsed();
+        let server_elapsed = server.join().expect("test server panicked");
+
+        assert!(result.is_err());
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "connection exceeded explicit timeout: {elapsed:?}"
+        );
+        assert!(
+            server_elapsed < Duration::from_secs(1),
+            "connection remained open after timeout: {server_elapsed:?}"
+        );
     }
 
     #[test]

--- a/src/ssh/backend/russh.rs
+++ b/src/ssh/backend/russh.rs
@@ -603,48 +603,24 @@ where
 
         let ssh_config = Config::try_from(opts)?;
         debug!("Connecting to '{}'", ssh_config.address);
-
-        let mut config = client::Config::default();
-
-        // Apply algorithm preferences from ssh config
-        apply_config_algo_prefs(&mut config, &ssh_config);
-
-        // Apply algorithm preferences from opts
-        apply_opts_algo_prefs(&mut config, opts);
-
-        let config = Arc::new(config);
-        let connection_attempts = ssh_config.connection_attempts.max(1);
-        let ca_signature_algorithms = ssh_config
-            .params
-            .ca_signature_algorithms
-            .algorithms()
-            .to_vec();
-        let mut attempt = 1;
-        let mut session = loop {
-            let handler =
-                CaSignaturePolicyHandler::new(T::default(), ca_signature_algorithms.clone());
-            match connect_with_timeout(
-                &runtime,
-                config.clone(),
-                handler,
-                ConnectionTarget {
-                    address: &ssh_config.address,
-                    bind_address: ssh_config.params.bind_address.as_deref(),
-                    bind_interface: ssh_config.params.bind_interface.as_deref(),
-                },
-                ssh_config.params.tcp_keep_alive,
-                ssh_config.connection_timeout,
-            ) {
-                Ok(session) => break session,
-                Err(err) if attempt < connection_attempts => {
-                    warn!("SSH connection attempt {attempt} failed: {err}");
-                    attempt += 1;
+        let proxy_jumps = ssh_config.proxy_jump_configs(opts)?;
+        let mut session = if let Some(first_jump) = proxy_jumps.first() {
+            let mut session = connect_russh_direct::<T>(&runtime, opts, first_jump)?;
+            auth::authenticate(&mut session, &runtime, opts, first_jump)?;
+            for next_hop in proxy_jumps
+                .iter()
+                .skip(1)
+                .chain(std::iter::once(&ssh_config))
+            {
+                session = connect_russh_through_jump::<T>(&runtime, opts, &session, next_hop)?;
+                if !std::ptr::eq(next_hop, &ssh_config) {
+                    auth::authenticate(&mut session, &runtime, opts, next_hop)?;
                 }
-                Err(err) => return Err(err),
             }
+            session
+        } else {
+            connect_russh_direct::<T>(&runtime, opts, &ssh_config)?
         };
-
-        // Authenticate
         auth::authenticate(&mut session, &runtime, opts, &ssh_config)?;
 
         Ok(Self { runtime, session })
@@ -732,6 +708,107 @@ where
                 error!("Failed to init SFTP session: {err}");
                 RemoteError::new_ex(RemoteErrorType::ProtocolError, err.to_string())
             })
+    }
+}
+
+fn russh_client_config(opts: &SshOpts, ssh_config: &Config) -> Arc<client::Config> {
+    let mut config = client::Config::default();
+    apply_config_algo_prefs(&mut config, ssh_config);
+    apply_opts_algo_prefs(&mut config, opts);
+    Arc::new(config)
+}
+
+fn connect_russh_direct<T>(
+    runtime: &Runtime,
+    opts: &SshOpts,
+    ssh_config: &Config,
+) -> RemoteResult<Handle<CaSignaturePolicyHandler<T>>>
+where
+    T: Handler + Default + Send + 'static,
+{
+    let config = russh_client_config(opts, ssh_config);
+    let connection_attempts = ssh_config.connection_attempts.max(1);
+    let ca_signature_algorithms = ssh_config
+        .params
+        .ca_signature_algorithms
+        .algorithms()
+        .to_vec();
+    let mut attempt = 1;
+    loop {
+        let handler = CaSignaturePolicyHandler::new(T::default(), ca_signature_algorithms.clone());
+        match connect_with_timeout(
+            runtime,
+            config.clone(),
+            handler,
+            ConnectionTarget {
+                address: &ssh_config.address,
+                bind_address: ssh_config.params.bind_address.as_deref(),
+                bind_interface: ssh_config.params.bind_interface.as_deref(),
+            },
+            ssh_config.params.tcp_keep_alive,
+            ssh_config.connection_timeout,
+        ) {
+            Ok(session) => return Ok(session),
+            Err(err) if attempt < connection_attempts => {
+                warn!("SSH connection attempt {attempt} failed: {err}");
+                attempt += 1;
+            }
+            Err(err) => return Err(err),
+        }
+    }
+}
+
+fn connect_russh_through_jump<T>(
+    runtime: &Runtime,
+    opts: &SshOpts,
+    jump_session: &Handle<CaSignaturePolicyHandler<T>>,
+    target: &Config,
+) -> RemoteResult<Handle<CaSignaturePolicyHandler<T>>>
+where
+    T: Handler + Default + Send + 'static,
+{
+    let config = russh_client_config(opts, target);
+    let ca_signature_algorithms = target.params.ca_signature_algorithms.algorithms().to_vec();
+    let mut attempt = 1;
+    loop {
+        let handler = CaSignaturePolicyHandler::new(T::default(), ca_signature_algorithms.clone());
+        let result = runtime.block_on(async {
+            tokio::time::timeout(target.connection_timeout, async {
+                let channel = jump_session
+                    .channel_open_direct_tcpip(
+                        target.resolved_host.clone(),
+                        u32::from(target.port),
+                        "127.0.0.1",
+                        0,
+                    )
+                    .await?;
+                client::connect_stream(config.clone(), channel.into_stream(), handler).await
+            })
+            .await
+        });
+        match result {
+            Ok(Ok(session)) => return Ok(session),
+            Ok(Err(err)) if attempt < target.connection_attempts.max(1) => {
+                warn!("SSH connection attempt {attempt} through ProxyJump failed: {err:?}");
+                attempt += 1;
+            }
+            Ok(Err(err)) => {
+                return Err(RemoteError::new_ex(
+                    RemoteErrorType::ConnectionError,
+                    format!("SSH connection through ProxyJump failed: {err:?}"),
+                ));
+            }
+            Err(err) if attempt < target.connection_attempts.max(1) => {
+                warn!("SSH connection attempt {attempt} through ProxyJump timed out: {err}");
+                attempt += 1;
+            }
+            Err(err) => {
+                return Err(RemoteError::new_ex(
+                    RemoteErrorType::ConnectionError,
+                    format!("SSH connection through ProxyJump timed out: {err}"),
+                ));
+            }
+        }
     }
 }
 
@@ -1836,6 +1913,35 @@ mod test {
             .runtime(runtime);
         let session = RusshSession::<NoCheckServerKey>::connect(&opts).unwrap();
         assert!(session.authenticated().unwrap());
+    }
+
+    #[test]
+    fn should_connect_through_proxy_jump() {
+        use crate::ssh::container::ProxyJumpServers;
+
+        let servers = ProxyJumpServers::start();
+        let config_file = ssh_mock::create_ssh_config_with_proxy_jump(
+            &servers.target_host,
+            2222,
+            servers.first_jump.port(),
+            &servers.second_jump_host,
+        );
+        let opts = SshOpts::new("target")
+            .config_file(config_file.path(), ParseRule::ALLOW_UNKNOWN_FIELDS)
+            .password("password")
+            .runtime(test_runtime());
+
+        let mut session = RusshSession::<NoCheckServerKey>::connect(&opts)
+            .expect("failed to connect through ProxyJump");
+        assert!(
+            session
+                .authenticated()
+                .expect("failed to query session state")
+        );
+        assert_eq!(
+            session.cmd("pwd").expect("command through proxy failed").0,
+            0
+        );
     }
 
     #[test]

--- a/src/ssh/backend/russh.rs
+++ b/src/ssh/backend/russh.rs
@@ -8,8 +8,8 @@ use std::future::Future as _;
 use std::io::{Read, Seek, Write};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, RwLock};
 use std::task::{Context, Poll};
 
 use remotefs::fs::{Metadata, ReadStream, WriteStream};
@@ -18,6 +18,7 @@ use russh::client::{ChannelOpenHandle, DisconnectReason, Handle, Handler, Msg, S
 use russh::keys::{Algorithm, PublicKey, PublicKeyOrCertificate};
 use russh::{Channel, ChannelId, ChannelOpenFailure, Disconnect, Sig, client};
 use russh_sftp::client::SftpSession;
+use ssh2_config::{RemoteForwardDestination, RemoteForwardListen};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::{TcpSocket, TcpStream};
 use tokio::runtime::Runtime;
@@ -54,15 +55,98 @@ struct CaSignaturePolicyHandler<T> {
     inner: T,
     allowed_algorithms: Vec<String>,
     forward_agent: bool,
+    remote_forwards: Arc<RemoteForwardState>,
 }
 
 impl<T> CaSignaturePolicyHandler<T> {
-    fn new(inner: T, allowed_algorithms: Vec<String>, forward_agent: bool) -> Self {
+    fn new(
+        inner: T,
+        allowed_algorithms: Vec<String>,
+        forward_agent: bool,
+        remote_forwards: Arc<RemoteForwardState>,
+    ) -> Self {
         Self {
             inner,
             allowed_algorithms,
             forward_agent,
+            remote_forwards,
         }
+    }
+}
+
+#[derive(Clone)]
+enum RemoteForwardKey {
+    Tcp { address: String, port: Option<u32> },
+    StreamLocal(PathBuf),
+}
+
+#[derive(Clone)]
+struct RemoteForwardRoute {
+    key: RemoteForwardKey,
+    destination: Option<RemoteForwardDestination>,
+    connect_timeout: std::time::Duration,
+}
+
+#[derive(Default)]
+struct RemoteForwardState {
+    active: AtomicBool,
+    routes: RwLock<Vec<RemoteForwardRoute>>,
+}
+
+impl RemoteForwardState {
+    fn tcp_route(
+        &self,
+        connected_address: &str,
+        connected_port: u32,
+    ) -> Option<RemoteForwardRoute> {
+        if !self.active.load(Ordering::Acquire) {
+            return None;
+        }
+        let routes = self.routes.read().expect("remote forward routes poisoned");
+        let mut matching_port = routes.iter().filter(|route| {
+            matches!(route.key, RemoteForwardKey::Tcp { port: Some(port), .. } if port == connected_port)
+        });
+        if let Some(first) = matching_port.next().cloned() {
+            if matching_port.next().is_none() {
+                return Some(first);
+            }
+            if let Some(route) = routes.iter().find(|route| {
+                matches!(
+                    &route.key,
+                    RemoteForwardKey::Tcp { address, port: Some(port) }
+                        if *port == connected_port && address == connected_address
+                )
+            }) {
+                return Some(route.clone());
+            }
+        }
+        routes
+            .iter()
+            .find(|route| {
+                matches!(
+                    &route.key,
+                    RemoteForwardKey::Tcp { address, port: None }
+                        if address.is_empty() || address == connected_address
+                )
+            })
+            .cloned()
+    }
+
+    fn streamlocal_route(&self, socket_path: &str) -> Option<RemoteForwardRoute> {
+        if !self.active.load(Ordering::Acquire) {
+            return None;
+        }
+        self.routes
+            .read()
+            .expect("remote forward routes poisoned")
+            .iter()
+            .find(|route| {
+                matches!(
+                    &route.key,
+                    RemoteForwardKey::StreamLocal(path) if path == Path::new(socket_path)
+                )
+            })
+            .cloned()
     }
 }
 
@@ -161,7 +245,7 @@ where
             .channel_open_failure(channel, reason, description, language, session)
     }
 
-    fn server_channel_open_forwarded_tcpip(
+    async fn server_channel_open_forwarded_tcpip(
         &mut self,
         channel: Channel<Msg>,
         connected_address: &str,
@@ -170,27 +254,41 @@ where
         originator_port: u32,
         reply: ChannelOpenHandle,
         session: &mut Session,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
-        self.inner.server_channel_open_forwarded_tcpip(
-            channel,
-            connected_address,
-            connected_port,
-            originator_address,
-            originator_port,
-            reply,
-            session,
-        )
+    ) -> Result<(), Self::Error> {
+        if let Some(route) = self
+            .remote_forwards
+            .tcp_route(connected_address, connected_port)
+        {
+            forward_remote_channel(channel, reply, route).await;
+            return Ok(());
+        }
+        self.inner
+            .server_channel_open_forwarded_tcpip(
+                channel,
+                connected_address,
+                connected_port,
+                originator_address,
+                originator_port,
+                reply,
+                session,
+            )
+            .await
     }
 
-    fn server_channel_open_forwarded_streamlocal(
+    async fn server_channel_open_forwarded_streamlocal(
         &mut self,
         channel: Channel<Msg>,
         socket_path: &str,
         reply: ChannelOpenHandle,
         session: &mut Session,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+    ) -> Result<(), Self::Error> {
+        if let Some(route) = self.remote_forwards.streamlocal_route(socket_path) {
+            forward_remote_channel(channel, reply, route).await;
+            return Ok(());
+        }
         self.inner
             .server_channel_open_forwarded_streamlocal(channel, socket_path, reply, session)
+            .await
     }
 
     async fn server_channel_open_agent_forward(
@@ -398,6 +496,284 @@ async fn forward_agent_channel(_channel: Channel<Msg>, _reply: ChannelOpenHandle
     warn!("SSH agent forwarding is unavailable on this platform");
 }
 
+async fn forward_remote_channel(
+    channel: Channel<Msg>,
+    reply: ChannelOpenHandle,
+    route: RemoteForwardRoute,
+) {
+    match route.destination {
+        Some(RemoteForwardDestination::Host { host, port }) => {
+            reply.accept().await;
+            tokio::spawn(async move {
+                let destination = connect_remote_tcp(&host, port, route.connect_timeout).await;
+                match destination {
+                    Ok(destination) => relay_remote_channel(channel, destination).await,
+                    Err(err) => {
+                        warn!("Could not connect RemoteForward destination {host}:{port}: {err}");
+                        if let Err(close_err) = channel.close().await {
+                            debug!("Could not close failed RemoteForward channel: {close_err}");
+                        }
+                    }
+                }
+            });
+        }
+        Some(RemoteForwardDestination::UnixSocket(path)) => {
+            forward_remote_unix_channel(channel, reply, path, route.connect_timeout).await;
+        }
+        None => {
+            reply.accept().await;
+            tokio::spawn(async move {
+                let mut channel = channel.into_stream();
+                match socks_connect(&mut channel, route.connect_timeout).await {
+                    Ok(mut destination) => {
+                        if let Err(err) =
+                            tokio::io::copy_bidirectional(&mut channel, &mut destination).await
+                        {
+                            debug!("Dynamic RemoteForward channel closed with an error: {err}");
+                        }
+                    }
+                    Err(err) => warn!("Dynamic RemoteForward failed: {err}"),
+                }
+            });
+        }
+    }
+}
+
+async fn connect_remote_tcp(
+    host: &str,
+    port: u16,
+    connect_timeout: std::time::Duration,
+) -> std::io::Result<TcpStream> {
+    if connect_timeout.is_zero() {
+        TcpStream::connect((host, port)).await
+    } else {
+        tokio::time::timeout(connect_timeout, TcpStream::connect((host, port)))
+            .await
+            .map_err(|_| {
+                std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "RemoteForward destination connect timed out",
+                )
+            })?
+    }
+}
+
+async fn relay_remote_channel<S>(channel: Channel<Msg>, mut destination: S)
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let mut channel = channel.into_stream();
+    if let Err(err) = tokio::io::copy_bidirectional(&mut channel, &mut destination).await {
+        debug!("RemoteForward channel closed with an error: {err}");
+    }
+}
+
+#[cfg(unix)]
+async fn forward_remote_unix_channel(
+    channel: Channel<Msg>,
+    reply: ChannelOpenHandle,
+    path: PathBuf,
+    connect_timeout: std::time::Duration,
+) {
+    reply.accept().await;
+    tokio::spawn(async move {
+        match connect_remote_unix(&path, connect_timeout).await {
+            Ok(destination) => relay_remote_channel(channel, destination).await,
+            Err(err) => {
+                warn!(
+                    "Could not connect RemoteForward destination {}: {err}",
+                    path.display()
+                );
+                if let Err(close_err) = channel.close().await {
+                    debug!("Could not close failed RemoteForward channel: {close_err}");
+                }
+            }
+        }
+    });
+}
+
+#[cfg(unix)]
+async fn connect_remote_unix(
+    path: &Path,
+    connect_timeout: std::time::Duration,
+) -> std::io::Result<tokio::net::UnixStream> {
+    if connect_timeout.is_zero() {
+        tokio::net::UnixStream::connect(path).await
+    } else {
+        tokio::time::timeout(connect_timeout, tokio::net::UnixStream::connect(path))
+            .await
+            .map_err(|_| {
+                std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "RemoteForward destination connect timed out",
+                )
+            })?
+    }
+}
+
+#[cfg(not(unix))]
+async fn forward_remote_unix_channel(
+    _channel: Channel<Msg>,
+    reply: ChannelOpenHandle,
+    path: PathBuf,
+    _connect_timeout: std::time::Duration,
+) {
+    warn!(
+        "Unix socket RemoteForward destination {} is unavailable on this platform",
+        path.display()
+    );
+    reply.reject(ChannelOpenFailure::ConnectFailed).await;
+}
+
+async fn socks_connect<S>(
+    stream: &mut S,
+    connect_timeout: std::time::Duration,
+) -> std::io::Result<TcpStream>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    let version = stream.read_u8().await?;
+    let (host, port) = match version {
+        4 => read_socks4_target(stream).await?,
+        5 => read_socks5_target(stream).await?,
+        _ => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("unsupported SOCKS version {version}"),
+            ));
+        }
+    };
+
+    let destination = connect_remote_tcp(&host, port, connect_timeout).await;
+    match destination {
+        Ok(destination) => {
+            if version == 4 {
+                stream.write_all(&[0, 90, 0, 0, 0, 0, 0, 0]).await?;
+            } else {
+                stream.write_all(&[5, 0, 0, 1, 0, 0, 0, 0, 0, 0]).await?;
+            }
+            Ok(destination)
+        }
+        Err(err) => {
+            if version == 4 {
+                let _ = stream.write_all(&[0, 91, 0, 0, 0, 0, 0, 0]).await;
+            } else {
+                let _ = stream.write_all(&[5, 1, 0, 1, 0, 0, 0, 0, 0, 0]).await;
+            }
+            Err(err)
+        }
+    }
+}
+
+async fn read_socks4_target<S>(stream: &mut S) -> std::io::Result<(String, u16)>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    let command = stream.read_u8().await?;
+    if command != 1 {
+        let _ = stream.write_all(&[0, 91, 0, 0, 0, 0, 0, 0]).await;
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "SOCKS4 supports CONNECT only",
+        ));
+    }
+    let port = stream.read_u16().await?;
+    let mut address = [0u8; 4];
+    stream.read_exact(&mut address).await?;
+    read_socks_string(stream).await?;
+    let host = if address[..3] == [0, 0, 0] && address[3] != 0 {
+        String::from_utf8(read_socks_string(stream).await?)
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err.to_string()))?
+    } else {
+        std::net::Ipv4Addr::from(address).to_string()
+    };
+    Ok((host, port))
+}
+
+async fn read_socks5_target<S>(stream: &mut S) -> std::io::Result<(String, u16)>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    let method_count = stream.read_u8().await? as usize;
+    let mut methods = vec![0u8; method_count];
+    stream.read_exact(&mut methods).await?;
+    if !methods.contains(&0) {
+        stream.write_all(&[5, 0xff]).await?;
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "SOCKS5 client did not offer no-authentication",
+        ));
+    }
+    stream.write_all(&[5, 0]).await?;
+    let request_version = stream.read_u8().await?;
+    let command = stream.read_u8().await?;
+    let reserved = stream.read_u8().await?;
+    if request_version != 5 || command != 1 || reserved != 0 {
+        let _ = stream.write_all(&[5, 7, 0, 1, 0, 0, 0, 0, 0, 0]).await;
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "SOCKS5 supports CONNECT only",
+        ));
+    }
+    let host = match stream.read_u8().await? {
+        1 => {
+            let mut address = [0u8; 4];
+            stream.read_exact(&mut address).await?;
+            std::net::Ipv4Addr::from(address).to_string()
+        }
+        3 => {
+            let length = stream.read_u8().await? as usize;
+            let mut domain = vec![0u8; length];
+            stream.read_exact(&mut domain).await?;
+            String::from_utf8(domain).map_err(|err| {
+                std::io::Error::new(std::io::ErrorKind::InvalidData, err.to_string())
+            })?
+        }
+        4 => {
+            let mut address = [0u8; 16];
+            stream.read_exact(&mut address).await?;
+            std::net::Ipv6Addr::from(address).to_string()
+        }
+        address_type => {
+            let _ = stream.write_all(&[5, 8, 0, 1, 0, 0, 0, 0, 0, 0]).await;
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                format!("unsupported SOCKS5 address type {address_type}"),
+            ));
+        }
+    };
+    let port = stream.read_u16().await?;
+    Ok((host, port))
+}
+
+async fn read_socks_string<S>(stream: &mut S) -> std::io::Result<Vec<u8>>
+where
+    S: AsyncRead + Unpin,
+{
+    use tokio::io::AsyncReadExt as _;
+
+    let mut value = Vec::new();
+    loop {
+        let byte = stream.read_u8().await?;
+        if byte == 0 {
+            return Ok(value);
+        }
+        if value.len() >= 1024 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "SOCKS string exceeds 1024 bytes",
+            ));
+        }
+        value.push(byte);
+    }
+}
+
 /// [`russh`](https://docs.rs/russh/latest/russh) session.
 pub struct RusshSession<T>
 where
@@ -406,6 +782,14 @@ where
     runtime: Arc<Runtime>,
     session: Handle<CaSignaturePolicyHandler<T>>,
     forward_agent: bool,
+    remote_forward_ports: Vec<u16>,
+    remote_forward_state: Arc<RemoteForwardState>,
+    remote_forwards: Vec<RegisteredRemoteForward>,
+}
+
+enum RegisteredRemoteForward {
+    Tcp { address: String, port: u32 },
+    StreamLocal(String),
 }
 
 /// SFTP handle for russh.
@@ -639,35 +1023,78 @@ where
         let ssh_config = Config::try_from(opts)?;
         debug!("Connecting to '{}'", ssh_config.address);
         let proxy_jumps = ssh_config.proxy_jump_configs(opts)?;
+        let remote_forward_state = Arc::new(RemoteForwardState::default());
         let mut session = if let Some(first_jump) = proxy_jumps.first() {
-            let mut session = connect_russh_direct::<T>(&runtime, opts, first_jump)?;
+            let mut session = connect_russh_direct::<T>(
+                &runtime,
+                opts,
+                first_jump,
+                Arc::new(RemoteForwardState::default()),
+            )?;
             auth::authenticate(&mut session, &runtime, opts, first_jump)?;
             for next_hop in proxy_jumps
                 .iter()
                 .skip(1)
                 .chain(std::iter::once(&ssh_config))
             {
-                session = connect_russh_through_jump::<T>(&runtime, opts, &session, next_hop)?;
+                let routes = if std::ptr::eq(next_hop, &ssh_config) {
+                    remote_forward_state.clone()
+                } else {
+                    Arc::new(RemoteForwardState::default())
+                };
+                session =
+                    connect_russh_through_jump::<T>(&runtime, opts, &session, next_hop, routes)?;
                 if !std::ptr::eq(next_hop, &ssh_config) {
                     auth::authenticate(&mut session, &runtime, opts, next_hop)?;
                 }
             }
             session
         } else {
-            connect_russh_direct::<T>(&runtime, opts, &ssh_config)?
+            connect_russh_direct::<T>(&runtime, opts, &ssh_config, remote_forward_state.clone())?
         };
         auth::authenticate(&mut session, &runtime, opts, &ssh_config)?;
+        let remote_forwards =
+            setup_russh_remote_forwards(&runtime, &session, &ssh_config, &remote_forward_state)?;
+        let remote_forward_ports = remote_forwards
+            .iter()
+            .filter_map(|forward| match forward {
+                RegisteredRemoteForward::Tcp { port, .. } => Some(
+                    u16::try_from(*port)
+                        .expect("RemoteForward assigned ports were validated during setup"),
+                ),
+                RegisteredRemoteForward::StreamLocal(_) => None,
+            })
+            .collect();
 
         Ok(Self {
             runtime,
             session,
             forward_agent: ssh_config.params.forward_agent.unwrap_or(false),
+            remote_forward_ports,
+            remote_forward_state,
+            remote_forwards,
         })
     }
 
     fn disconnect(&self) -> RemoteResult<()> {
+        self.remote_forward_state
+            .active
+            .store(false, Ordering::Release);
         self.runtime
             .block_on(async {
+                for forward in self.remote_forwards.iter().rev() {
+                    let result = match forward {
+                        RegisteredRemoteForward::Tcp { address, port } => {
+                            self.session.cancel_tcpip_forward(address, *port).await
+                        }
+                        RegisteredRemoteForward::StreamLocal(path) => {
+                            self.session.cancel_streamlocal_forward(path).await
+                        }
+                    };
+                    if let Err(err) = result {
+                        warn!("Failed to cancel RemoteForward: {err}");
+                    }
+                }
                 self.session
                     .disconnect(Disconnect::ByApplication, "Closed by user", "en_US")
                     .await
@@ -676,6 +1103,10 @@ where
                 log::error!("failed to disconnect {err}");
                 RemoteError::new_ex(RemoteErrorType::ConnectionError, err.to_string())
             })
+    }
+
+    fn remote_forward_ports(&self) -> &[u16] {
+        &self.remote_forward_ports
     }
 
     fn banner(&self) -> RemoteResult<Option<String>> {
@@ -780,6 +1211,7 @@ fn connect_russh_direct<T>(
     runtime: &Runtime,
     opts: &SshOpts,
     ssh_config: &Config,
+    remote_forwards: Arc<RemoteForwardState>,
 ) -> RemoteResult<Handle<CaSignaturePolicyHandler<T>>>
 where
     T: Handler + Default + Send + 'static,
@@ -797,6 +1229,7 @@ where
             T::default(),
             ca_signature_algorithms.clone(),
             ssh_config.params.forward_agent.unwrap_or(false),
+            remote_forwards.clone(),
         );
         match connect_with_timeout(
             runtime,
@@ -825,6 +1258,7 @@ fn connect_russh_through_jump<T>(
     opts: &SshOpts,
     jump_session: &Handle<CaSignaturePolicyHandler<T>>,
     target: &Config,
+    remote_forwards: Arc<RemoteForwardState>,
 ) -> RemoteResult<Handle<CaSignaturePolicyHandler<T>>>
 where
     T: Handler + Default + Send + 'static,
@@ -837,6 +1271,7 @@ where
             T::default(),
             ca_signature_algorithms.clone(),
             target.params.forward_agent.unwrap_or(false),
+            remote_forwards.clone(),
         );
         let result = runtime.block_on(async {
             tokio::time::timeout(target.connection_timeout, async {
@@ -876,6 +1311,178 @@ where
             }
         }
     }
+}
+
+fn setup_russh_remote_forwards<T>(
+    runtime: &Runtime,
+    session: &Handle<T>,
+    config: &Config,
+    state: &RemoteForwardState,
+) -> RemoteResult<Vec<RegisteredRemoteForward>>
+where
+    T: Handler,
+{
+    #[cfg(not(unix))]
+    if config.params.remote_forward.iter().any(|forward| {
+        matches!(
+            forward.destination,
+            Some(RemoteForwardDestination::UnixSocket(_))
+        )
+    }) {
+        return Err(RemoteError::new_ex(
+            RemoteErrorType::UnsupportedFeature,
+            "Unix socket RemoteForward destinations are unavailable on this platform",
+        ));
+    }
+
+    let mut registered = Vec::new();
+    state
+        .routes
+        .write()
+        .expect("remote forward routes poisoned")
+        .clear();
+    state.active.store(true, Ordering::Release);
+    for forward in &config.params.remote_forward {
+        let pending_key = match &forward.listen {
+            RemoteForwardListen::Port(port) => RemoteForwardKey::Tcp {
+                address: "localhost".to_string(),
+                port: (*port != 0).then_some(u32::from(*port)),
+            },
+            RemoteForwardListen::Host { host, port } => RemoteForwardKey::Tcp {
+                address: if host.is_empty() || host == "*" {
+                    String::new()
+                } else {
+                    host.clone()
+                },
+                port: (*port != 0).then_some(u32::from(*port)),
+            },
+            RemoteForwardListen::UnixSocket(path) => {
+                if path.to_str().is_none() {
+                    state.active.store(false, Ordering::Release);
+                    state
+                        .routes
+                        .write()
+                        .expect("remote forward routes poisoned")
+                        .clear();
+                    cancel_russh_remote_forwards(runtime, session, &registered);
+                    return Err(RemoteError::new_ex(
+                        RemoteErrorType::ProtocolError,
+                        "RemoteForward Unix socket path is not valid UTF-8",
+                    ));
+                }
+                RemoteForwardKey::StreamLocal(path.clone())
+            }
+        };
+        let route_index = {
+            let mut routes = state
+                .routes
+                .write()
+                .expect("remote forward routes poisoned");
+            let route_index = routes.len();
+            routes.push(RemoteForwardRoute {
+                key: pending_key.clone(),
+                destination: forward.destination.clone(),
+                connect_timeout: config.connection_timeout,
+            });
+            route_index
+        };
+
+        let result = match &pending_key {
+            RemoteForwardKey::Tcp { address, port } => runtime
+                .block_on(session.tcpip_forward(address, port.unwrap_or(0)))
+                .map(|returned_port| RemoteForwardKey::Tcp {
+                    address: address.clone(),
+                    port: Some(port.unwrap_or(returned_port)),
+                }),
+            RemoteForwardKey::StreamLocal(path) => runtime
+                .block_on(session.streamlocal_forward(
+                    path.to_str().expect("Unix socket path was validated above"),
+                ))
+                .map(|()| pending_key.clone()),
+        };
+
+        match result {
+            Ok(key) => {
+                let registration = match &key {
+                    RemoteForwardKey::Tcp {
+                        address,
+                        port: Some(port),
+                    } => RegisteredRemoteForward::Tcp {
+                        address: address.clone(),
+                        port: *port,
+                    },
+                    RemoteForwardKey::StreamLocal(path) => RegisteredRemoteForward::StreamLocal(
+                        path.to_str()
+                            .expect("Unix socket path was validated above")
+                            .to_string(),
+                    ),
+                    RemoteForwardKey::Tcp { port: None, .. } => {
+                        unreachable!("successful TCP registration has an assigned port")
+                    }
+                };
+                if matches!(registration, RegisteredRemoteForward::Tcp { port, .. } if port > u32::from(u16::MAX))
+                {
+                    registered.push(registration);
+                    state.active.store(false, Ordering::Release);
+                    state
+                        .routes
+                        .write()
+                        .expect("remote forward routes poisoned")
+                        .clear();
+                    cancel_russh_remote_forwards(runtime, session, &registered);
+                    return Err(RemoteError::new_ex(
+                        RemoteErrorType::ProtocolError,
+                        "SSH server returned an invalid RemoteForward port",
+                    ));
+                }
+                state
+                    .routes
+                    .write()
+                    .expect("remote forward routes poisoned")[route_index]
+                    .key = key;
+                registered.push(registration);
+            }
+            Err(err) => {
+                state.active.store(false, Ordering::Release);
+                state
+                    .routes
+                    .write()
+                    .expect("remote forward routes poisoned")
+                    .clear();
+                cancel_russh_remote_forwards(runtime, session, &registered);
+                return Err(RemoteError::new_ex(
+                    RemoteErrorType::ProtocolError,
+                    format!("Could not configure RemoteForward: {err}"),
+                ));
+            }
+        }
+    }
+
+    Ok(registered)
+}
+
+fn cancel_russh_remote_forwards<T>(
+    runtime: &Runtime,
+    session: &Handle<T>,
+    registered: &[RegisteredRemoteForward],
+) where
+    T: Handler,
+{
+    runtime.block_on(async {
+        for forward in registered.iter().rev() {
+            let result = match forward {
+                RegisteredRemoteForward::Tcp { address, port } => {
+                    session.cancel_tcpip_forward(address, *port).await
+                }
+                RegisteredRemoteForward::StreamLocal(path) => {
+                    session.cancel_streamlocal_forward(path).await
+                }
+            };
+            if let Err(err) = result {
+                warn!("Failed to roll back RemoteForward: {err}");
+            }
+        }
+    });
 }
 
 impl Sftp for RusshSftp {
@@ -1763,6 +2370,7 @@ mod test {
             NoCheckServerKey,
             vec!["rsa-sha2-256".to_string()],
             false,
+            Arc::new(RemoteForwardState::default()),
         );
         assert!(
             !runtime
@@ -1770,8 +2378,12 @@ mod test {
                 .expect("failed to check rejected certificate")
         );
 
-        let mut accepted =
-            CaSignaturePolicyHandler::new(NoCheckServerKey, vec!["ssh-ed25519".to_string()], false);
+        let mut accepted = CaSignaturePolicyHandler::new(
+            NoCheckServerKey,
+            vec!["ssh-ed25519".to_string()],
+            false,
+            Arc::new(RemoteForwardState::default()),
+        );
         assert!(
             runtime
                 .block_on(accepted.check_server_key(&server_key))
@@ -2429,6 +3041,128 @@ mod test {
             .password("password")
             .runtime(test_runtime());
         assert!(RusshSession::<NoCheckServerKey>::connect(&opts).is_err());
+    }
+
+    #[test]
+    fn should_apply_configured_remote_forward() {
+        let container = crate::ssh::container::OpensshServer::start_with_tcp_forwarding();
+        let (destination_port, destination) = ssh_mock::start_tcp_echo_server();
+        let (dynamic_destination_port, dynamic_destination) = ssh_mock::start_tcp_echo_server();
+        let remote_port = 43003;
+        let mut config_file = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            config_file,
+            "Host forwarded\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    RemoteForward 127.0.0.1:{remote_port} 127.0.0.1:{destination_port}\n    RemoteForward 0",
+            port = container.port(),
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("forwarded")
+            .config_file(config_file.path(), ParseRule::STRICT)
+            .password("password")
+            .runtime(test_runtime());
+        let mut session =
+            RusshSession::<NoCheckServerKey>::connect(&opts).expect("failed to connect");
+        let dynamic_port = *session
+            .remote_forward_ports()
+            .get(1)
+            .expect("dynamic RemoteForward did not report its assigned port");
+
+        let (status, output) = session
+            .cmd(format!("printf ping | nc -w 5 127.0.0.1 {remote_port}"))
+            .expect("failed to use configured remote forward");
+        assert_eq!(status, 0, "remote forwarding command failed: {output}");
+        assert_eq!(output, "pong\n");
+        destination.join().expect("TCP echo server panicked");
+
+        let (status, output) = session
+            .cmd(ssh_mock::socks5_test_command(
+                dynamic_port,
+                dynamic_destination_port,
+            ))
+            .expect("failed to use dynamic RemoteForward");
+        assert_eq!(status, 0, "dynamic forwarding command failed: {output}");
+        assert_eq!(output, "pong\n");
+        dynamic_destination
+            .join()
+            .expect("dynamic TCP echo server panicked");
+    }
+
+    #[test]
+    fn should_close_remote_forward_when_destination_connect_fails() {
+        let container = crate::ssh::container::OpensshServer::start_with_tcp_forwarding();
+        let destination = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+            .expect("failed to reserve closed destination port")
+            .local_addr()
+            .expect("failed to inspect closed destination port")
+            .port();
+        let remote_port = 43303;
+        let mut config_file = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            config_file,
+            "Host forwarded\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    RemoteForward 127.0.0.1:{remote_port} 127.0.0.1:{destination}",
+            port = container.port(),
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("forwarded")
+            .config_file(config_file.path(), ParseRule::STRICT)
+            .password("password")
+            .runtime(test_runtime());
+        let mut session =
+            RusshSession::<NoCheckServerKey>::connect(&opts).expect("failed to connect");
+
+        let started = std::time::Instant::now();
+        let (status, output) = session
+            .cmd(format!(
+                "nc -w 10 127.0.0.1 {remote_port} </dev/null; printf closed"
+            ))
+            .expect("failed to exercise rejected RemoteForward destination");
+        assert_eq!(status, 0, "remote forwarding command failed: {output}");
+        assert_eq!(output, "closed");
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(5),
+            "failed RemoteForward channel was not closed promptly"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn should_apply_remote_forward_with_unix_sockets() {
+        let container = crate::ssh::container::OpensshServer::start_with_tcp_forwarding();
+        let (_tcp_directory, tcp_destination_path, tcp_destination) =
+            ssh_mock::start_unix_echo_server();
+        let (_unix_directory, unix_destination_path, unix_destination) =
+            ssh_mock::start_unix_echo_server();
+        let remote_port = 43203;
+        let remote_socket = format!("/tmp/remotefs-ssh-{}.sock", std::process::id());
+        let mut config_file = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            config_file,
+            "Host forwarded\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    RemoteForward 127.0.0.1:{remote_port} {tcp_destination}\n    RemoteForward {remote_socket} {unix_destination}",
+            port = container.port(),
+            tcp_destination = tcp_destination_path.display(),
+            unix_destination = unix_destination_path.display(),
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("forwarded")
+            .config_file(config_file.path(), ParseRule::STRICT)
+            .password("password")
+            .runtime(test_runtime());
+        let mut session =
+            RusshSession::<NoCheckServerKey>::connect(&opts).expect("failed to connect");
+
+        let (status, output) = session
+            .cmd(format!("printf ping | nc -w 5 127.0.0.1 {remote_port}"))
+            .expect("failed to use Unix destination RemoteForward");
+        assert_eq!(status, 0, "remote forwarding command failed: {output}");
+        assert_eq!(output, "pong\n");
+        tcp_destination.join().expect("Unix echo server panicked");
+
+        let (status, output) = session
+            .cmd(format!("printf ping | nc -w 5 -U {remote_socket}"))
+            .expect("failed to use Unix listener RemoteForward");
+        assert_eq!(status, 0, "Unix listener command failed: {output}");
+        assert_eq!(output, "pong\n");
+        unix_destination.join().expect("Unix echo server panicked");
     }
 
     #[test]

--- a/src/ssh/backend/russh.rs
+++ b/src/ssh/backend/russh.rs
@@ -1018,6 +1018,16 @@ impl Read for PipelinedSftpReader {
 fn apply_config_algo_prefs(config: &mut client::Config, ssh_config: &Config) {
     let params = &ssh_config.params;
 
+    config.preferred.compression = if params.compression.unwrap_or(false) {
+        Cow::Owned(vec![
+            russh::compression::ZLIB_LEGACY,
+            russh::compression::ZLIB,
+            russh::compression::NONE,
+        ])
+    } else {
+        Cow::Owned(vec![russh::compression::NONE])
+    };
+
     // KEX algorithms
     let kex: Vec<russh::kex::Name> = params
         .kex_algorithms
@@ -1227,6 +1237,30 @@ mod test {
                 .build()
                 .unwrap(),
         )
+    }
+
+    #[test]
+    fn should_apply_configured_compression() {
+        for (configured, expected) in [
+            (Some(true), vec!["zlib@openssh.com", "zlib", "none"]),
+            (Some(false), vec!["none"]),
+            (None, vec!["none"]),
+        ] {
+            let mut ssh_config =
+                Config::try_from(&SshOpts::new("localhost")).expect("failed to create config");
+            ssh_config.params.compression = configured;
+            let mut config = client::Config::default();
+
+            apply_config_algo_prefs(&mut config, &ssh_config);
+
+            let actual = config
+                .preferred
+                .compression
+                .iter()
+                .map(AsRef::as_ref)
+                .collect::<Vec<_>>();
+            assert_eq!(actual, expected);
+        }
     }
 
     #[test]

--- a/src/ssh/backend/russh.rs
+++ b/src/ssh/backend/russh.rs
@@ -1421,6 +1421,37 @@ mod test {
     }
 
     #[test]
+    fn should_disable_public_key_authentication_from_ssh_config() {
+        use crate::ssh::container::OpensshServer;
+
+        let container = OpensshServer::start();
+        let runtime = test_runtime();
+        let key_file = ssh_mock::create_key_file();
+        let config_file = ssh_mock::create_ssh_config_with_identity_and_pubkey_authentication(
+            container.port(),
+            key_file.path(),
+            false,
+        );
+        let opts = SshOpts::new("sftp")
+            .config_file(config_file.path(), ParseRule::ALLOW_UNKNOWN_FIELDS)
+            .runtime(runtime);
+
+        assert!(RusshSession::<NoCheckServerKey>::connect(&opts).is_err());
+
+        let opts = SshOpts::new("sftp")
+            .config_file(config_file.path(), ParseRule::ALLOW_UNKNOWN_FIELDS)
+            .password("password")
+            .runtime(test_runtime());
+        let session = RusshSession::<NoCheckServerKey>::connect(&opts)
+            .expect("password authentication should remain enabled");
+        assert!(
+            session
+                .authenticated()
+                .expect("failed to query session state")
+        );
+    }
+
+    #[test]
     #[cfg(unix)]
     fn should_connect_to_ssh_server_auth_ssh_agent() {
         use std::process::Command;

--- a/src/ssh/backend/russh.rs
+++ b/src/ssh/backend/russh.rs
@@ -19,7 +19,7 @@ use russh::keys::{Algorithm, PublicKeyOrCertificate};
 use russh::{Disconnect, client};
 use russh_sftp::client::SftpSession;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-use tokio::net::TcpStream;
+use tokio::net::{TcpSocket, TcpStream};
 use tokio::runtime::Runtime;
 use tokio::time::{Instant, Sleep};
 
@@ -147,6 +147,7 @@ fn connect_with_timeout<T>(
     runtime: &Runtime,
     config: Arc<client::Config>,
     address: &str,
+    bind_address: Option<&str>,
     timeout: std::time::Duration,
 ) -> RemoteResult<Handle<T>>
 where
@@ -154,7 +155,9 @@ where
 {
     let deadline = Instant::now() + timeout;
     let stream = runtime
-        .block_on(async { tokio::time::timeout_at(deadline, TcpStream::connect(address)).await })
+        .block_on(async {
+            tokio::time::timeout_at(deadline, connect_tcp(address, bind_address)).await
+        })
         .map_err(|err| {
             let msg = format!("SSH connection timed out: {err}");
             error!("{msg}");
@@ -183,6 +186,50 @@ where
         error!("{msg}");
         RemoteError::new_ex(RemoteErrorType::ConnectionError, msg)
     })
+}
+
+async fn connect_tcp(address: &str, bind_address: Option<&str>) -> std::io::Result<TcpStream> {
+    let Some(bind_address) = bind_address else {
+        return TcpStream::connect(address).await;
+    };
+
+    let source_addresses: Vec<_> = tokio::net::lookup_host((bind_address, 0)).await?.collect();
+    let target_addresses: Vec<_> = tokio::net::lookup_host(address).await?.collect();
+    let mut last_error = None;
+    for target_address in target_addresses {
+        for source_address in source_addresses
+            .iter()
+            .filter(|source| source.is_ipv4() == target_address.is_ipv4())
+        {
+            let socket = if target_address.is_ipv4() {
+                TcpSocket::new_v4()
+            } else {
+                TcpSocket::new_v6()
+            };
+            let socket = match socket {
+                Ok(socket) => socket,
+                Err(err) => {
+                    last_error = Some(err);
+                    continue;
+                }
+            };
+            if let Err(err) = socket.bind(*source_address) {
+                last_error = Some(err);
+                continue;
+            }
+            match socket.connect(target_address).await {
+                Ok(stream) => return Ok(stream),
+                Err(err) => last_error = Some(err),
+            }
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::AddrNotAvailable,
+            format!("no compatible address family found for BindAddress {bind_address}"),
+        )
+    }))
 }
 
 impl<T> SshSession for RusshSession<T>
@@ -218,6 +265,7 @@ where
                 &runtime,
                 config.clone(),
                 &ssh_config.address,
+                ssh_config.params.bind_address.as_deref(),
                 ssh_config.connection_timeout,
             ) {
                 Ok(session) => break session,
@@ -1393,6 +1441,37 @@ mod test {
             .expect("connection should succeed on the configured retry");
         session.disconnect().expect("failed to disconnect");
         drop(session);
+    }
+
+    #[test]
+    fn should_apply_configured_bind_address() {
+        let container = crate::ssh::container::OpensshServer::start();
+        let port = container.port();
+        let mut valid_config = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            valid_config,
+            "Host bound\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    BindAddress 127.0.0.1"
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("bound")
+            .config_file(valid_config.path(), ParseRule::STRICT)
+            .password("password")
+            .runtime(test_runtime());
+        let session = RusshSession::<NoCheckServerKey>::connect(&opts)
+            .expect("failed to connect with an available bind address");
+        session.disconnect().expect("failed to disconnect");
+
+        let mut invalid_config = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            invalid_config,
+            "Host bound\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    BindAddress 192.0.2.1"
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("bound")
+            .config_file(invalid_config.path(), ParseRule::STRICT)
+            .password("password")
+            .runtime(test_runtime());
+        assert!(RusshSession::<NoCheckServerKey>::connect(&opts).is_err());
     }
 
     #[test]

--- a/src/ssh/backend/russh.rs
+++ b/src/ssh/backend/russh.rs
@@ -143,6 +143,48 @@ impl AsyncWrite for ConnectionDeadlineStream {
     }
 }
 
+fn connect_with_timeout<T>(
+    runtime: &Runtime,
+    config: Arc<client::Config>,
+    address: &str,
+    timeout: std::time::Duration,
+) -> RemoteResult<Handle<T>>
+where
+    T: Handler + Default + Send + 'static,
+{
+    let deadline = Instant::now() + timeout;
+    let stream = runtime
+        .block_on(async { tokio::time::timeout_at(deadline, TcpStream::connect(address)).await })
+        .map_err(|err| {
+            let msg = format!("SSH connection timed out: {err}");
+            error!("{msg}");
+            RemoteError::new_ex(RemoteErrorType::ConnectionError, msg)
+        })?
+        .map_err(|err| {
+            let msg = format!("SSH connection failed: {err}");
+            error!("{msg}");
+            RemoteError::new_ex(RemoteErrorType::ConnectionError, msg)
+        })?;
+    if config.nodelay
+        && let Err(err) = stream.set_nodelay(true)
+    {
+        warn!("Failed to enable TCP_NODELAY: {err}");
+    }
+
+    let deadline_active = Arc::new(AtomicBool::new(true));
+    let connection_deadline_active = deadline_active.clone();
+    let session_result = runtime.block_on(async {
+        let stream = ConnectionDeadlineStream::new(stream, deadline, connection_deadline_active);
+        client::connect_stream(config, stream, T::default()).await
+    });
+    deadline_active.store(false, Ordering::Release);
+    session_result.map_err(|err| {
+        let msg = format!("SSH connection failed: {err:?}");
+        error!("{msg}");
+        RemoteError::new_ex(RemoteErrorType::ConnectionError, msg)
+    })
+}
+
 impl<T> SshSession for RusshSession<T>
 where
     T: Handler + Default + Send + 'static,
@@ -169,40 +211,23 @@ where
         apply_opts_algo_prefs(&mut config, opts);
 
         let config = Arc::new(config);
-        let deadline = Instant::now() + ssh_config.connection_timeout;
-        let stream = runtime
-            .block_on(async {
-                tokio::time::timeout_at(deadline, TcpStream::connect(&ssh_config.address)).await
-            })
-            .map_err(|err| {
-                let msg = format!("SSH connection timed out: {err}");
-                error!("{msg}");
-                RemoteError::new_ex(RemoteErrorType::ConnectionError, msg)
-            })?
-            .map_err(|err| {
-                let msg = format!("SSH connection failed: {err}");
-                error!("{msg}");
-                RemoteError::new_ex(RemoteErrorType::ConnectionError, msg)
-            })?;
-        if config.nodelay
-            && let Err(err) = stream.set_nodelay(true)
-        {
-            warn!("Failed to enable TCP_NODELAY: {err}");
-        }
-
-        let deadline_active = Arc::new(AtomicBool::new(true));
-        let connection_deadline_active = deadline_active.clone();
-        let session_result = runtime.block_on(async {
-            let stream =
-                ConnectionDeadlineStream::new(stream, deadline, connection_deadline_active);
-            client::connect_stream(config, stream, T::default()).await
-        });
-        deadline_active.store(false, Ordering::Release);
-        let mut session = session_result.map_err(|err| {
-            let msg = format!("SSH connection failed: {err:?}");
-            error!("{msg}");
-            RemoteError::new_ex(RemoteErrorType::ConnectionError, msg)
-        })?;
+        let connection_attempts = ssh_config.connection_attempts.max(1);
+        let mut attempt = 1;
+        let mut session = loop {
+            match connect_with_timeout::<T>(
+                &runtime,
+                config.clone(),
+                &ssh_config.address,
+                ssh_config.connection_timeout,
+            ) {
+                Ok(session) => break session,
+                Err(err) if attempt < connection_attempts => {
+                    warn!("SSH connection attempt {attempt} failed: {err}");
+                    attempt += 1;
+                }
+                Err(err) => return Err(err),
+            }
+        };
 
         // Authenticate
         auth::authenticate(&mut session, &runtime, opts, &ssh_config)?;
@@ -1347,6 +1372,27 @@ mod test {
             server_elapsed < Duration::from_secs(1),
             "connection remained open after timeout: {server_elapsed:?}"
         );
+    }
+
+    #[test]
+    fn should_retry_connection_using_configured_attempts() {
+        let container = crate::ssh::container::OpensshServer::start();
+        let (port, _proxy) = ssh_mock::start_flaky_proxy(container.port(), 1);
+        let mut config_file = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            config_file,
+            "Host flaky\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    ConnectionAttempts 2"
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("flaky")
+            .config_file(config_file.path(), ParseRule::STRICT)
+            .password("password")
+            .runtime(test_runtime());
+
+        let session = RusshSession::<NoCheckServerKey>::connect(&opts)
+            .expect("connection should succeed on the configured retry");
+        session.disconnect().expect("failed to disconnect");
+        drop(session);
     }
 
     #[test]

--- a/src/ssh/backend/russh.rs
+++ b/src/ssh/backend/russh.rs
@@ -1574,7 +1574,11 @@ where
 #[cfg(test)]
 mod test {
 
+    #[cfg(unix)]
+    use std::ffi::OsString;
     use std::sync::Arc;
+    #[cfg(unix)]
+    use std::sync::Mutex;
     use std::time::{Duration, Instant};
 
     use ssh2_config::ParseRule;
@@ -1583,6 +1587,61 @@ mod test {
     use super::*;
     use crate::KeyMethod;
     use crate::mock::ssh as ssh_mock;
+
+    #[cfg(unix)]
+    static SSH_AGENT_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[cfg(unix)]
+    struct TestSshAgent {
+        auth_sock: String,
+        pid: String,
+        previous_auth_sock: Option<OsString>,
+    }
+
+    #[cfg(unix)]
+    impl TestSshAgent {
+        fn start() -> Self {
+            use std::process::Command;
+
+            let output = Command::new("ssh-agent")
+                .arg("-s")
+                .output()
+                .expect("failed to spawn ssh-agent (is openssh installed?)");
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let auth_sock = parse_agent_var(&stdout, "SSH_AUTH_SOCK")
+                .expect("ssh-agent did not report SSH_AUTH_SOCK");
+            let pid = parse_agent_var(&stdout, "SSH_AGENT_PID")
+                .expect("ssh-agent did not report SSH_AGENT_PID");
+            let previous_auth_sock = std::env::var_os("SSH_AUTH_SOCK");
+            // SAFETY: agent tests serialize access with `SSH_AGENT_ENV_LOCK`.
+            unsafe {
+                std::env::set_var("SSH_AUTH_SOCK", &auth_sock);
+            }
+
+            Self {
+                auth_sock,
+                pid,
+                previous_auth_sock,
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    impl Drop for TestSshAgent {
+        fn drop(&mut self) {
+            use std::process::Command;
+
+            // SAFETY: agent tests serialize access with `SSH_AGENT_ENV_LOCK`.
+            unsafe {
+                if let Some(previous_auth_sock) = self.previous_auth_sock.as_ref() {
+                    std::env::set_var("SSH_AUTH_SOCK", previous_auth_sock);
+                } else {
+                    std::env::remove_var("SSH_AUTH_SOCK");
+                }
+            }
+            let _ = Command::new("kill").arg(&self.pid).status();
+        }
+    }
 
     fn test_runtime() -> Arc<Runtime> {
         Arc::new(
@@ -1876,17 +1935,10 @@ mod test {
         use crate::ssh::container::OpensshServer;
 
         crate::mock::logger();
-
-        // Spawn a dedicated ssh-agent and load the mock key into it.
-        let agent_out = Command::new("ssh-agent")
-            .arg("-s")
-            .output()
-            .expect("failed to spawn ssh-agent (is openssh installed?)");
-        let agent_stdout = String::from_utf8_lossy(&agent_out.stdout);
-        let auth_sock = parse_agent_var(&agent_stdout, "SSH_AUTH_SOCK")
-            .expect("ssh-agent did not report SSH_AUTH_SOCK");
-        let agent_pid = parse_agent_var(&agent_stdout, "SSH_AGENT_PID")
-            .expect("ssh-agent did not report SSH_AGENT_PID");
+        let _env_lock = SSH_AGENT_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let agent = TestSshAgent::start();
 
         let key_file = ssh_mock::create_key_file();
         // ssh-add refuses keys with loose permissions.
@@ -1896,18 +1948,13 @@ mod test {
             .expect("chmod failed");
         let added = Command::new("ssh-add")
             .arg(key_file.path())
-            .env("SSH_AUTH_SOCK", &auth_sock)
+            .env("SSH_AUTH_SOCK", &agent.auth_sock)
             .status()
             .expect("ssh-add failed to run");
         assert!(added.success(), "ssh-add could not load the mock key");
 
         // Point the russh agent client at our agent. No key storage, no password:
         // authentication must succeed through the agent alone.
-        // SAFETY: tests in this module run single-threaded (`--test-threads=1`).
-        unsafe {
-            std::env::set_var("SSH_AUTH_SOCK", &auth_sock);
-        }
-
         let container = OpensshServer::start();
         let port = container.port();
         let runtime = test_runtime();
@@ -1918,16 +1965,60 @@ mod test {
             .runtime(runtime);
 
         let result = RusshSession::<NoCheckServerKey>::connect(&opts);
-
-        // Tear the agent down regardless of the outcome.
-        // SAFETY: see above.
-        unsafe {
-            std::env::remove_var("SSH_AUTH_SOCK");
-        }
-        let _ = Command::new("kill").arg(&agent_pid).status();
-
         let session = result.expect("could not authenticate via ssh agent");
         assert!(session.authenticated().unwrap());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn should_add_identity_file_to_ssh_agent_from_config() {
+        use std::io::Write as _;
+
+        use crate::ssh::container::OpensshServer;
+
+        let _env_lock = SSH_AGENT_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let agent = TestSshAgent::start();
+        let container = OpensshServer::start();
+        // This Ed25519 key is not authorized by the server. OpenSSH still adds a
+        // file key to the agent when it is loaded, before password fallback.
+        let (key_file, _certificate_file) = ssh_mock::create_certificate_key_files();
+        let mut config_file = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            config_file,
+            "Host sftp\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    IdentityFile {identity}\n    AddKeysToAgent yes",
+            port = container.port(),
+            identity = key_file.path().display(),
+        )
+        .expect("failed to write SSH config");
+        let runtime = test_runtime();
+        let opts = SshOpts::new("sftp")
+            .config_file(config_file.path(), ParseRule::ALLOW_UNKNOWN_FIELDS)
+            .password("password")
+            .runtime(runtime.clone());
+
+        RusshSession::<NoCheckServerKey>::connect(&opts)
+            .expect("failed to authenticate using IdentityFile");
+
+        let identities = runtime
+            .block_on(async {
+                let mut client =
+                    russh::keys::agent::client::AgentClient::connect_uds(&agent.auth_sock).await?;
+                client.request_identities().await
+            })
+            .expect("failed to list agent identities");
+        let expected_key = russh::keys::load_secret_key(key_file.path(), None)
+            .expect("failed to load expected private key")
+            .public_key()
+            .fingerprint(russh::keys::HashAlg::Sha256);
+
+        assert!(identities.iter().any(|identity| {
+            identity
+                .public_key()
+                .fingerprint(russh::keys::HashAlg::Sha256)
+                == expected_key
+        }));
     }
 
     /// Parse a `NAME=value;` assignment from `ssh-agent -s` output.

--- a/src/ssh/backend/russh.rs
+++ b/src/ssh/backend/russh.rs
@@ -8,7 +8,7 @@ use std::future::Future as _;
 use std::io::{Read, Seek, Write};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 use std::task::{Context, Poll};
 
@@ -24,7 +24,7 @@ use tokio::net::{TcpSocket, TcpStream};
 use tokio::runtime::Runtime;
 use tokio::time::{Instant, Sleep};
 
-use super::{SshSession, WriteMode, interface, socket};
+use super::{MAX_FORWARD_CONNECTIONS, SshSession, WriteMode, interface, socket};
 use crate::SshOpts;
 use crate::ssh::backend::Sftp;
 use crate::ssh::config::Config;
@@ -90,10 +90,26 @@ struct RemoteForwardRoute {
 #[derive(Default)]
 struct RemoteForwardState {
     active: AtomicBool,
+    active_channels: AtomicUsize,
     routes: RwLock<Vec<RemoteForwardRoute>>,
 }
 
+struct ForwardChannelPermit {
+    state: Arc<RemoteForwardState>,
+}
+
 impl RemoteForwardState {
+    fn try_acquire_channel(self: &Arc<Self>) -> Option<ForwardChannelPermit> {
+        self.active_channels
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |active| {
+                (active < MAX_FORWARD_CONNECTIONS).then_some(active + 1)
+            })
+            .ok()
+            .map(|_| ForwardChannelPermit {
+                state: Arc::clone(self),
+            })
+    }
+
     fn tcp_route(
         &self,
         connected_address: &str,
@@ -147,6 +163,12 @@ impl RemoteForwardState {
                 )
             })
             .cloned()
+    }
+}
+
+impl Drop for ForwardChannelPermit {
+    fn drop(&mut self) {
+        self.state.active_channels.fetch_sub(1, Ordering::Release);
     }
 }
 
@@ -259,7 +281,11 @@ where
             .remote_forwards
             .tcp_route(connected_address, connected_port)
         {
-            forward_remote_channel(channel, reply, route).await;
+            let Some(permit) = self.remote_forwards.try_acquire_channel() else {
+                reply.reject(ChannelOpenFailure::ResourceShortage).await;
+                return Ok(());
+            };
+            forward_remote_channel(channel, reply, route, permit).await;
             return Ok(());
         }
         self.inner
@@ -283,7 +309,11 @@ where
         session: &mut Session,
     ) -> Result<(), Self::Error> {
         if let Some(route) = self.remote_forwards.streamlocal_route(socket_path) {
-            forward_remote_channel(channel, reply, route).await;
+            let Some(permit) = self.remote_forwards.try_acquire_channel() else {
+                reply.reject(ChannelOpenFailure::ResourceShortage).await;
+                return Ok(());
+            };
+            forward_remote_channel(channel, reply, route, permit).await;
             return Ok(());
         }
         self.inner
@@ -304,7 +334,11 @@ where
                 .await;
         }
 
-        forward_agent_channel(channel, reply).await;
+        let Some(permit) = self.remote_forwards.try_acquire_channel() else {
+            reply.reject(ChannelOpenFailure::ResourceShortage).await;
+            return Ok(());
+        };
+        forward_agent_channel(channel, reply, permit).await;
         Ok(())
     }
 
@@ -472,7 +506,11 @@ where
 }
 
 #[cfg(unix)]
-async fn forward_agent_channel(channel: Channel<Msg>, reply: ChannelOpenHandle) {
+async fn forward_agent_channel(
+    channel: Channel<Msg>,
+    reply: ChannelOpenHandle,
+    permit: ForwardChannelPermit,
+) {
     let agent = match russh::keys::agent::client::AgentClient::connect_env().await {
         Ok(agent) => agent,
         Err(err) => {
@@ -483,6 +521,7 @@ async fn forward_agent_channel(channel: Channel<Msg>, reply: ChannelOpenHandle) 
 
     reply.accept().await;
     tokio::spawn(async move {
+        let _permit = permit;
         let mut channel = channel.into_stream();
         let mut agent = agent.into_inner();
         if let Err(err) = tokio::io::copy_bidirectional(&mut channel, &mut agent).await {
@@ -492,7 +531,11 @@ async fn forward_agent_channel(channel: Channel<Msg>, reply: ChannelOpenHandle) 
 }
 
 #[cfg(not(unix))]
-async fn forward_agent_channel(_channel: Channel<Msg>, _reply: ChannelOpenHandle) {
+async fn forward_agent_channel(
+    _channel: Channel<Msg>,
+    _reply: ChannelOpenHandle,
+    _permit: ForwardChannelPermit,
+) {
     warn!("SSH agent forwarding is unavailable on this platform");
 }
 
@@ -500,11 +543,13 @@ async fn forward_remote_channel(
     channel: Channel<Msg>,
     reply: ChannelOpenHandle,
     route: RemoteForwardRoute,
+    permit: ForwardChannelPermit,
 ) {
     match route.destination {
         Some(RemoteForwardDestination::Host { host, port }) => {
             reply.accept().await;
             tokio::spawn(async move {
+                let _permit = permit;
                 let destination = connect_remote_tcp(&host, port, route.connect_timeout).await;
                 match destination {
                     Ok(destination) => relay_remote_channel(channel, destination).await,
@@ -518,11 +563,12 @@ async fn forward_remote_channel(
             });
         }
         Some(RemoteForwardDestination::UnixSocket(path)) => {
-            forward_remote_unix_channel(channel, reply, path, route.connect_timeout).await;
+            forward_remote_unix_channel(channel, reply, path, route.connect_timeout, permit).await;
         }
         None => {
             reply.accept().await;
             tokio::spawn(async move {
+                let _permit = permit;
                 let mut channel = channel.into_stream();
                 match socks_connect(&mut channel, route.connect_timeout).await {
                     Ok(mut destination) => {
@@ -574,9 +620,11 @@ async fn forward_remote_unix_channel(
     reply: ChannelOpenHandle,
     path: PathBuf,
     connect_timeout: std::time::Duration,
+    permit: ForwardChannelPermit,
 ) {
     reply.accept().await;
     tokio::spawn(async move {
+        let _permit = permit;
         match connect_remote_unix(&path, connect_timeout).await {
             Ok(destination) => relay_remote_channel(channel, destination).await,
             Err(err) => {
@@ -617,6 +665,7 @@ async fn forward_remote_unix_channel(
     reply: ChannelOpenHandle,
     path: PathBuf,
     _connect_timeout: std::time::Duration,
+    _permit: ForwardChannelPermit,
 ) {
     warn!(
         "Unix socket RemoteForward destination {} is unavailable on this platform",
@@ -894,43 +943,52 @@ fn connect_with_timeout<T>(
 where
     T: Handler + Send + 'static,
 {
-    let deadline = Instant::now() + timeout;
-    let stream = runtime
-        .block_on(async {
-            tokio::time::timeout_at(
-                deadline,
-                connect_tcp(
-                    target.address,
-                    target.bind_address,
-                    target.bind_interface,
-                    tcp_keep_alive,
-                ),
-            )
-            .await
-        })
-        .map_err(|err| {
-            let msg = format!("SSH connection timed out: {err}");
-            error!("{msg}");
-            RemoteError::new_ex(RemoteErrorType::ConnectionError, msg)
-        })?
-        .map_err(|err| {
-            let msg = format!("SSH connection failed: {err}");
-            error!("{msg}");
-            RemoteError::new_ex(RemoteErrorType::ConnectionError, msg)
-        })?;
+    let deadline = (!timeout.is_zero())
+        .then(|| Instant::now().checked_add(timeout))
+        .flatten();
+    let connect = || {
+        connect_tcp(
+            target.address,
+            target.bind_address,
+            target.bind_interface,
+            tcp_keep_alive,
+        )
+    };
+    let stream = match deadline {
+        Some(deadline) => runtime
+            .block_on(async { tokio::time::timeout_at(deadline, connect()).await })
+            .map_err(|err| {
+                let msg = format!("SSH connection timed out: {err}");
+                error!("{msg}");
+                RemoteError::new_ex(RemoteErrorType::ConnectionError, msg)
+            })?,
+        None => runtime.block_on(connect()),
+    }
+    .map_err(|err| {
+        let msg = format!("SSH connection failed: {err}");
+        error!("{msg}");
+        RemoteError::new_ex(RemoteErrorType::ConnectionError, msg)
+    })?;
     if config.nodelay
         && let Err(err) = stream.set_nodelay(true)
     {
         warn!("Failed to enable TCP_NODELAY: {err}");
     }
 
-    let deadline_active = Arc::new(AtomicBool::new(true));
-    let connection_deadline_active = deadline_active.clone();
-    let session_result = runtime.block_on(async {
-        let stream = ConnectionDeadlineStream::new(stream, deadline, connection_deadline_active);
-        client::connect_stream(config, stream, handler).await
-    });
-    deadline_active.store(false, Ordering::Release);
+    let session_result = match deadline {
+        Some(deadline) => {
+            let deadline_active = Arc::new(AtomicBool::new(true));
+            let connection_deadline_active = deadline_active.clone();
+            let result = runtime.block_on(async {
+                let stream =
+                    ConnectionDeadlineStream::new(stream, deadline, connection_deadline_active);
+                client::connect_stream(config, stream, handler).await
+            });
+            deadline_active.store(false, Ordering::Release);
+            result
+        }
+        None => runtime.block_on(async { client::connect_stream(config, stream, handler).await }),
+    };
     session_result.map_err(|err| {
         let msg = format!("SSH connection failed: {err:?}");
         error!("{msg}");
@@ -1273,20 +1331,23 @@ where
             target.params.forward_agent.unwrap_or(false),
             remote_forwards.clone(),
         );
-        let result = runtime.block_on(async {
-            tokio::time::timeout(target.connection_timeout, async {
-                let channel = jump_session
-                    .channel_open_direct_tcpip(
-                        target.resolved_host.clone(),
-                        u32::from(target.port),
-                        "127.0.0.1",
-                        0,
-                    )
-                    .await?;
-                client::connect_stream(config.clone(), channel.into_stream(), handler).await
-            })
-            .await
-        });
+        let connect = async {
+            let channel = jump_session
+                .channel_open_direct_tcpip(
+                    target.resolved_host.clone(),
+                    u32::from(target.port),
+                    "127.0.0.1",
+                    0,
+                )
+                .await?;
+            client::connect_stream(config.clone(), channel.into_stream(), handler).await
+        };
+        let result = if target.connection_timeout.is_zero() {
+            Ok(runtime.block_on(connect))
+        } else {
+            runtime
+                .block_on(async { tokio::time::timeout(target.connection_timeout, connect).await })
+        };
         match result {
             Ok(Ok(session)) => return Ok(session),
             Ok(Err(err)) if attempt < target.connection_attempts.max(1) => {
@@ -2360,6 +2421,22 @@ mod test {
     }
 
     #[test]
+    fn should_limit_concurrent_forwarded_channels() {
+        let state = Arc::new(RemoteForwardState::default());
+        let mut permits = (0..MAX_FORWARD_CONNECTIONS)
+            .map(|_| {
+                state
+                    .try_acquire_channel()
+                    .expect("forwarded channel should remain within the limit")
+            })
+            .collect::<Vec<_>>();
+
+        assert!(state.try_acquire_channel().is_none());
+        permits.pop();
+        assert!(state.try_acquire_channel().is_some());
+    }
+
+    #[test]
     fn should_apply_ca_signature_algorithms_to_host_certificates() {
         let certificate = russh::keys::Certificate::from_openssh(ssh_mock::MOCK_USER_CERTIFICATE)
             .expect("failed to parse test certificate");
@@ -2580,6 +2657,28 @@ mod test {
             session.cmd("pwd").expect("command through proxy failed").0,
             0
         );
+    }
+
+    #[test]
+    fn should_disable_proxy_jump_timeout_when_zero() {
+        use crate::ssh::container::ProxyJumpServers;
+
+        let servers = ProxyJumpServers::start();
+        let config_file = ssh_mock::create_ssh_config_with_proxy_jump(
+            &servers.target_host,
+            2222,
+            servers.first_jump.port(),
+            &servers.second_jump_host,
+        );
+        let opts = SshOpts::new("target")
+            .config_file(config_file.path(), ParseRule::ALLOW_UNKNOWN_FIELDS)
+            .connection_timeout(Duration::ZERO)
+            .password("password")
+            .runtime(test_runtime());
+
+        let session = RusshSession::<NoCheckServerKey>::connect(&opts)
+            .expect("zero connection timeout should allow ProxyJump handshakes to complete");
+        session.disconnect().expect("failed to disconnect");
     }
 
     #[test]
@@ -2943,6 +3042,21 @@ mod test {
             server_elapsed < Duration::from_secs(1),
             "connection remained open after timeout: {server_elapsed:?}"
         );
+    }
+
+    #[test]
+    fn should_disable_connection_timeout_when_zero() {
+        let container = crate::ssh::container::OpensshServer::start();
+        let opts = SshOpts::new("127.0.0.1")
+            .port(container.port())
+            .username("sftp")
+            .password("password")
+            .connection_timeout(Duration::ZERO)
+            .runtime(test_runtime());
+
+        let session = RusshSession::<NoCheckServerKey>::connect(&opts)
+            .expect("zero connection timeout should allow the connection to complete");
+        session.disconnect().expect("failed to disconnect");
     }
 
     #[test]

--- a/src/ssh/backend/russh.rs
+++ b/src/ssh/backend/russh.rs
@@ -1044,19 +1044,15 @@ fn apply_config_algo_prefs(config: &mut client::Config, ssh_config: &Config) {
     }
 
     // Host key algorithms
-    let host_keys: Vec<Algorithm> = params
-        .host_key_algorithms
-        .algorithms()
-        .iter()
-        .filter_map(|name| {
-            name.parse::<Algorithm>()
-                .map_err(|err| warn!("Unsupported host key algorithm '{name}': {err}"))
-                .ok()
-        })
-        .collect();
-    if !host_keys.is_empty() {
-        config.preferred.key = Cow::Owned(host_keys);
-    }
+    let (host_keys, host_key_certificates) = parse_host_key_algorithms(
+        params
+            .host_key_algorithms
+            .algorithms()
+            .iter()
+            .map(String::as_str),
+    );
+    config.preferred.host_key_certificates = Cow::Owned(host_key_certificates);
+    config.preferred.key = Cow::Owned(host_keys);
 
     // Cipher algorithms
     let ciphers: Vec<russh::cipher::Name> = params
@@ -1112,15 +1108,9 @@ fn apply_opts_algo_prefs(config: &mut client::Config, opts: &SshOpts) {
                 }
             }
             MethodType::HostKey => {
-                let keys: Vec<Algorithm> = names
-                    .iter()
-                    .filter_map(|name| {
-                        name.parse::<Algorithm>()
-                            .map_err(|err| warn!("Unsupported host key algorithm '{name}': {err}"))
-                            .ok()
-                    })
-                    .collect();
-                if !keys.is_empty() {
+                let (keys, certificates) = parse_host_key_algorithms(names.iter().copied());
+                if !keys.is_empty() || !certificates.is_empty() {
+                    config.preferred.host_key_certificates = Cow::Owned(certificates);
                     config.preferred.key = Cow::Owned(keys);
                 }
             }
@@ -1158,6 +1148,34 @@ fn apply_opts_algo_prefs(config: &mut client::Config, opts: &SshOpts) {
             }
         }
     }
+}
+
+/// Split host key algorithm names into plain key and certificate preferences.
+///
+/// Russh advertises certificate preferences before plain key preferences because its API exposes
+/// them as separate lists, so cross-list ordering cannot be preserved.
+fn parse_host_key_algorithms<'a>(
+    names: impl IntoIterator<Item = &'a str>,
+) -> (Vec<Algorithm>, Vec<Algorithm>) {
+    let mut keys = Vec::new();
+    let mut certificates = Vec::new();
+
+    for name in names {
+        let result = if name.ends_with("-cert-v01@openssh.com") {
+            Algorithm::new_certificate(name)
+                .map(|algorithm| certificates.push(algorithm))
+                .map_err(|err| err.to_string())
+        } else {
+            name.parse::<Algorithm>()
+                .map(|algorithm| keys.push(algorithm))
+                .map_err(|err| err.to_string())
+        };
+        if let Err(err) = result {
+            warn!("Unsupported host key algorithm '{name}': {err}");
+        }
+    }
+
+    (keys, certificates)
 }
 
 /// Execute a shell command on the remote server via a russh channel.
@@ -1228,6 +1246,7 @@ mod test {
     use tempfile::NamedTempFile;
 
     use super::*;
+    use crate::KeyMethod;
     use crate::mock::ssh as ssh_mock;
 
     fn test_runtime() -> Arc<Runtime> {
@@ -1261,6 +1280,82 @@ mod test {
                 .collect::<Vec<_>>();
             assert_eq!(actual, expected);
         }
+    }
+
+    #[test]
+    fn should_apply_configured_host_key_certificates() {
+        let mut ssh_config =
+            Config::try_from(&SshOpts::new("localhost")).expect("failed to create config");
+        ssh_config.params.host_key_algorithms = ssh2_config::Algorithms::new([
+            "ssh-ed25519-cert-v01@openssh.com",
+            "rsa-sha2-512-cert-v01@openssh.com",
+            "ecdsa-sha2-nistp256",
+        ]);
+        let mut config = client::Config::default();
+
+        apply_config_algo_prefs(&mut config, &ssh_config);
+
+        let certificates = config
+            .preferred
+            .host_key_certificates
+            .iter()
+            .map(Algorithm::to_certificate_type)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            certificates,
+            [
+                "ssh-ed25519-cert-v01@openssh.com",
+                "rsa-sha2-512-cert-v01@openssh.com"
+            ]
+        );
+        let plain_keys = config
+            .preferred
+            .key
+            .iter()
+            .map(AsRef::as_ref)
+            .collect::<Vec<_>>();
+        assert_eq!(plain_keys, ["ecdsa-sha2-nistp256"]);
+    }
+
+    #[test]
+    fn should_override_configured_host_key_certificates_with_options() {
+        let mut ssh_config =
+            Config::try_from(&SshOpts::new("localhost")).expect("failed to create config");
+        ssh_config.params.host_key_algorithms =
+            ssh2_config::Algorithms::new(["ssh-ed25519-cert-v01@openssh.com", "ssh-ed25519"]);
+        let opts = SshOpts::new("localhost").method(KeyMethod::new(
+            MethodType::HostKey,
+            &["ecdsa-sha2-nistp256".to_string()],
+        ));
+        let mut config = client::Config::default();
+
+        apply_config_algo_prefs(&mut config, &ssh_config);
+        apply_opts_algo_prefs(&mut config, &opts);
+
+        assert!(config.preferred.host_key_certificates.is_empty());
+        let plain_keys = config
+            .preferred
+            .key
+            .iter()
+            .map(AsRef::as_ref)
+            .collect::<Vec<_>>();
+        assert_eq!(plain_keys, ["ecdsa-sha2-nistp256"]);
+    }
+
+    #[test]
+    fn should_preserve_host_key_preferences_for_empty_options() {
+        let mut ssh_config =
+            Config::try_from(&SshOpts::new("localhost")).expect("failed to create config");
+        ssh_config.params.host_key_algorithms =
+            ssh2_config::Algorithms::new(["ssh-ed25519-cert-v01@openssh.com", "ssh-ed25519"]);
+        let opts = SshOpts::new("localhost").method(KeyMethod::new(MethodType::HostKey, &[]));
+        let mut config = client::Config::default();
+
+        apply_config_algo_prefs(&mut config, &ssh_config);
+        apply_opts_algo_prefs(&mut config, &opts);
+
+        assert_eq!(config.preferred.host_key_certificates.len(), 1);
+        assert_eq!(config.preferred.key.len(), 1);
     }
 
     #[test]

--- a/src/ssh/backend/russh.rs
+++ b/src/ssh/backend/russh.rs
@@ -1452,6 +1452,39 @@ mod test {
     }
 
     #[test]
+    fn should_apply_pubkey_accepted_algorithms_from_ssh_config() {
+        use crate::ssh::container::OpensshServer;
+
+        let container = OpensshServer::start();
+        let key_file = ssh_mock::create_key_file();
+        let legacy_config = ssh_mock::create_ssh_config_with_identity_and_pubkey_algorithms(
+            container.port(),
+            key_file.path(),
+            "ssh-rsa",
+        );
+        let opts = SshOpts::new("sftp")
+            .config_file(legacy_config.path(), ParseRule::ALLOW_UNKNOWN_FIELDS)
+            .runtime(test_runtime());
+        assert!(RusshSession::<NoCheckServerKey>::connect(&opts).is_err());
+
+        let modern_config = ssh_mock::create_ssh_config_with_identity_and_pubkey_algorithms(
+            container.port(),
+            key_file.path(),
+            "rsa-sha2-256",
+        );
+        let opts = SshOpts::new("sftp")
+            .config_file(modern_config.path(), ParseRule::ALLOW_UNKNOWN_FIELDS)
+            .runtime(test_runtime());
+        let session = RusshSession::<NoCheckServerKey>::connect(&opts)
+            .expect("failed to authenticate with the accepted RSA SHA-2 algorithm");
+        assert!(
+            session
+                .authenticated()
+                .expect("failed to query session state")
+        );
+    }
+
+    #[test]
     #[cfg(unix)]
     fn should_connect_to_ssh_server_auth_ssh_agent() {
         use std::process::Command;

--- a/src/ssh/backend/russh.rs
+++ b/src/ssh/backend/russh.rs
@@ -23,7 +23,7 @@ use tokio::net::{TcpSocket, TcpStream};
 use tokio::runtime::Runtime;
 use tokio::time::{Instant, Sleep};
 
-use super::{SshSession, WriteMode};
+use super::{SshSession, WriteMode, interface};
 use crate::SshOpts;
 use crate::ssh::backend::Sftp;
 use crate::ssh::config::Config;
@@ -148,6 +148,7 @@ fn connect_with_timeout<T>(
     config: Arc<client::Config>,
     address: &str,
     bind_address: Option<&str>,
+    bind_interface: Option<&str>,
     timeout: std::time::Duration,
 ) -> RemoteResult<Handle<T>>
 where
@@ -156,7 +157,8 @@ where
     let deadline = Instant::now() + timeout;
     let stream = runtime
         .block_on(async {
-            tokio::time::timeout_at(deadline, connect_tcp(address, bind_address)).await
+            tokio::time::timeout_at(deadline, connect_tcp(address, bind_address, bind_interface))
+                .await
         })
         .map_err(|err| {
             let msg = format!("SSH connection timed out: {err}");
@@ -188,12 +190,24 @@ where
     })
 }
 
-async fn connect_tcp(address: &str, bind_address: Option<&str>) -> std::io::Result<TcpStream> {
-    let Some(bind_address) = bind_address else {
+async fn connect_tcp(
+    address: &str,
+    bind_address: Option<&str>,
+    bind_interface: Option<&str>,
+) -> std::io::Result<TcpStream> {
+    if bind_address.is_none() && bind_interface.is_none() {
         return TcpStream::connect(address).await;
-    };
+    }
 
-    let source_addresses: Vec<_> = tokio::net::lookup_host((bind_address, 0)).await?.collect();
+    let source_addresses = if let Some(bind_address) = bind_address {
+        tokio::net::lookup_host((bind_address, 0))
+            .await?
+            .collect::<Vec<_>>()
+    } else {
+        interface::addresses(bind_interface.expect("checked above"))?
+            .into_iter()
+            .collect()
+    };
     let target_addresses: Vec<_> = tokio::net::lookup_host(address).await?.collect();
     let mut last_error = None;
     for target_address in target_addresses {
@@ -224,10 +238,14 @@ async fn connect_tcp(address: &str, bind_address: Option<&str>) -> std::io::Resu
         }
     }
 
+    let source = bind_address.map_or_else(
+        || format!("BindInterface {}", bind_interface.expect("checked above")),
+        |address| format!("BindAddress {address}"),
+    );
     Err(last_error.unwrap_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::AddrNotAvailable,
-            format!("no compatible address family found for BindAddress {bind_address}"),
+            format!("no compatible address family found for {source}"),
         )
     }))
 }
@@ -266,6 +284,7 @@ where
                 config.clone(),
                 &ssh_config.address,
                 ssh_config.params.bind_address.as_deref(),
+                ssh_config.params.bind_interface.as_deref(),
                 ssh_config.connection_timeout,
             ) {
                 Ok(session) => break session,
@@ -1465,6 +1484,52 @@ mod test {
         writeln!(
             invalid_config,
             "Host bound\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    BindAddress 192.0.2.1"
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("bound")
+            .config_file(invalid_config.path(), ParseRule::STRICT)
+            .password("password")
+            .runtime(test_runtime());
+        assert!(RusshSession::<NoCheckServerKey>::connect(&opts).is_err());
+
+        let mut precedence_config = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            precedence_config,
+            "Host bound\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    BindAddress 127.0.0.1\n    BindInterface remotefs-ssh-missing-interface"
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("bound")
+            .config_file(precedence_config.path(), ParseRule::STRICT)
+            .password("password")
+            .runtime(test_runtime());
+        let session = RusshSession::<NoCheckServerKey>::connect(&opts)
+            .expect("BindAddress should take precedence over BindInterface");
+        session.disconnect().expect("failed to disconnect");
+    }
+
+    #[test]
+    fn should_apply_configured_bind_interface() {
+        let container = crate::ssh::container::OpensshServer::start();
+        let port = container.port();
+        let interface = ssh_mock::ipv4_loopback_interface();
+        let mut valid_config = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            valid_config,
+            "Host bound\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    BindInterface {interface}"
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("bound")
+            .config_file(valid_config.path(), ParseRule::STRICT)
+            .password("password")
+            .runtime(test_runtime());
+        let session = RusshSession::<NoCheckServerKey>::connect(&opts)
+            .expect("failed to connect through the configured interface");
+        session.disconnect().expect("failed to disconnect");
+
+        let mut invalid_config = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            invalid_config,
+            "Host bound\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    BindInterface remotefs-ssh-missing-interface"
         )
         .expect("failed to write SSH config");
         let opts = SshOpts::new("bound")

--- a/src/ssh/backend/russh.rs
+++ b/src/ssh/backend/russh.rs
@@ -53,13 +53,15 @@ impl Handler for NoCheckServerKey {
 struct CaSignaturePolicyHandler<T> {
     inner: T,
     allowed_algorithms: Vec<String>,
+    forward_agent: bool,
 }
 
 impl<T> CaSignaturePolicyHandler<T> {
-    fn new(inner: T, allowed_algorithms: Vec<String>) -> Self {
+    fn new(inner: T, allowed_algorithms: Vec<String>, forward_agent: bool) -> Self {
         Self {
             inner,
             allowed_algorithms,
+            forward_agent,
         }
     }
 }
@@ -191,14 +193,21 @@ where
             .server_channel_open_forwarded_streamlocal(channel, socket_path, reply, session)
     }
 
-    fn server_channel_open_agent_forward(
+    async fn server_channel_open_agent_forward(
         &mut self,
         channel: Channel<Msg>,
         reply: ChannelOpenHandle,
         session: &mut Session,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
-        self.inner
-            .server_channel_open_agent_forward(channel, reply, session)
+    ) -> Result<(), Self::Error> {
+        if !self.forward_agent {
+            return self
+                .inner
+                .server_channel_open_agent_forward(channel, reply, session)
+                .await;
+        }
+
+        forward_agent_channel(channel, reply).await;
+        Ok(())
     }
 
     fn should_accept_unknown_server_channel(
@@ -364,6 +373,31 @@ where
     }
 }
 
+#[cfg(unix)]
+async fn forward_agent_channel(channel: Channel<Msg>, reply: ChannelOpenHandle) {
+    let agent = match russh::keys::agent::client::AgentClient::connect_env().await {
+        Ok(agent) => agent,
+        Err(err) => {
+            warn!("Could not connect to the configured SSH agent: {err}");
+            return;
+        }
+    };
+
+    reply.accept().await;
+    tokio::spawn(async move {
+        let mut channel = channel.into_stream();
+        let mut agent = agent.into_inner();
+        if let Err(err) = tokio::io::copy_bidirectional(&mut channel, &mut agent).await {
+            debug!("SSH agent forwarding channel closed with an error: {err}");
+        }
+    });
+}
+
+#[cfg(not(unix))]
+async fn forward_agent_channel(_channel: Channel<Msg>, _reply: ChannelOpenHandle) {
+    warn!("SSH agent forwarding is unavailable on this platform");
+}
+
 /// [`russh`](https://docs.rs/russh/latest/russh) session.
 pub struct RusshSession<T>
 where
@@ -371,6 +405,7 @@ where
 {
     runtime: Arc<Runtime>,
     session: Handle<CaSignaturePolicyHandler<T>>,
+    forward_agent: bool,
 }
 
 /// SFTP handle for russh.
@@ -623,7 +658,11 @@ where
         };
         auth::authenticate(&mut session, &runtime, opts, &ssh_config)?;
 
-        Ok(Self { runtime, session })
+        Ok(Self {
+            runtime,
+            session,
+            forward_agent: ssh_config.params.forward_agent.unwrap_or(false),
+        })
     }
 
     fn disconnect(&self) -> RemoteResult<()> {
@@ -664,13 +703,14 @@ where
         let escaped = cmd.replace('\'', r#"'\''"#);
         let wrapped = format!("sh -c '{escaped}'");
 
-        self.runtime
-            .block_on(async { perform_shell_cmd(&self.session, &wrapped).await })
+        self.runtime.block_on(async {
+            perform_shell_cmd(&self.session, &wrapped, self.forward_agent).await
+        })
     }
 
     fn scp_recv(&self, path: &Path) -> RemoteResult<Box<dyn Read + Send>> {
         self.runtime
-            .block_on(async { scp::recv(&self.session, path).await })
+            .block_on(async { scp::recv(&self.session, path, self.forward_agent).await })
     }
 
     fn scp_send(
@@ -681,8 +721,17 @@ where
         _times: Option<(u64, u64)>,
     ) -> RemoteResult<Box<dyn Write + Send>> {
         let runtime = self.runtime.clone();
-        self.runtime
-            .block_on(async { scp::send(&self.session, remote_path, mode, size, runtime).await })
+        self.runtime.block_on(async {
+            scp::send(
+                &self.session,
+                remote_path,
+                mode,
+                size,
+                runtime,
+                self.forward_agent,
+            )
+            .await
+        })
     }
 
     fn sftp(&self) -> RemoteResult<Self::Sftp> {
@@ -690,6 +739,9 @@ where
             .runtime
             .block_on(async {
                 let channel = self.session.channel_open_session().await?;
+                if self.forward_agent {
+                    channel.agent_forward(true).await?;
+                }
                 channel.request_subsystem(true, "sftp").await?;
                 Ok(channel)
             })
@@ -741,7 +793,11 @@ where
         .to_vec();
     let mut attempt = 1;
     loop {
-        let handler = CaSignaturePolicyHandler::new(T::default(), ca_signature_algorithms.clone());
+        let handler = CaSignaturePolicyHandler::new(
+            T::default(),
+            ca_signature_algorithms.clone(),
+            ssh_config.params.forward_agent.unwrap_or(false),
+        );
         match connect_with_timeout(
             runtime,
             config.clone(),
@@ -777,7 +833,11 @@ where
     let ca_signature_algorithms = target.params.ca_signature_algorithms.algorithms().to_vec();
     let mut attempt = 1;
     loop {
-        let handler = CaSignaturePolicyHandler::new(T::default(), ca_signature_algorithms.clone());
+        let handler = CaSignaturePolicyHandler::new(
+            T::default(),
+            ca_signature_algorithms.clone(),
+            target.params.forward_agent.unwrap_or(false),
+        );
         let result = runtime.block_on(async {
             tokio::time::timeout(target.connection_timeout, async {
                 let channel = jump_session
@@ -1600,11 +1660,15 @@ fn parse_host_key_algorithms<'a>(
 ///
 /// Opens a session channel, executes the command, collects stdout,
 /// and returns the exit code with the output.
-async fn perform_shell_cmd<T>(session: &Handle<T>, cmd: &str) -> RemoteResult<(u32, String)>
+async fn perform_shell_cmd<T>(
+    session: &Handle<T>,
+    cmd: &str,
+    forward_agent: bool,
+) -> RemoteResult<(u32, String)>
 where
     T: Handler,
 {
-    let mut channel = open_channel(session).await?;
+    let mut channel = open_channel(session, forward_agent).await?;
 
     channel.exec(true, cmd).await.map_err(|err| {
         RemoteError::new_ex(
@@ -1642,26 +1706,34 @@ where
 }
 
 /// Open a session channel on the given handle.
-async fn open_channel<T>(session: &Handle<T>) -> RemoteResult<russh::Channel<russh::client::Msg>>
+async fn open_channel<T>(
+    session: &Handle<T>,
+    forward_agent: bool,
+) -> RemoteResult<russh::Channel<russh::client::Msg>>
 where
     T: Handler,
 {
-    session.channel_open_session().await.map_err(|err| {
+    let channel = session.channel_open_session().await.map_err(|err| {
         RemoteError::new_ex(
             RemoteErrorType::ProtocolError,
             format!("Could not open channel: {err}"),
         )
-    })
+    })?;
+    if forward_agent {
+        channel.agent_forward(true).await.map_err(|err| {
+            RemoteError::new_ex(
+                RemoteErrorType::ProtocolError,
+                format!("Could not request SSH agent forwarding: {err}"),
+            )
+        })?;
+    }
+    Ok(channel)
 }
 
 #[cfg(test)]
 mod test {
 
-    #[cfg(unix)]
-    use std::ffi::OsString;
     use std::sync::Arc;
-    #[cfg(unix)]
-    use std::sync::Mutex;
     use std::time::{Duration, Instant};
 
     use ssh2_config::ParseRule;
@@ -1670,61 +1742,6 @@ mod test {
     use super::*;
     use crate::KeyMethod;
     use crate::mock::ssh as ssh_mock;
-
-    #[cfg(unix)]
-    static SSH_AGENT_ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    #[cfg(unix)]
-    struct TestSshAgent {
-        auth_sock: String,
-        pid: String,
-        previous_auth_sock: Option<OsString>,
-    }
-
-    #[cfg(unix)]
-    impl TestSshAgent {
-        fn start() -> Self {
-            use std::process::Command;
-
-            let output = Command::new("ssh-agent")
-                .arg("-s")
-                .output()
-                .expect("failed to spawn ssh-agent (is openssh installed?)");
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let auth_sock = parse_agent_var(&stdout, "SSH_AUTH_SOCK")
-                .expect("ssh-agent did not report SSH_AUTH_SOCK");
-            let pid = parse_agent_var(&stdout, "SSH_AGENT_PID")
-                .expect("ssh-agent did not report SSH_AGENT_PID");
-            let previous_auth_sock = std::env::var_os("SSH_AUTH_SOCK");
-            // SAFETY: agent tests serialize access with `SSH_AGENT_ENV_LOCK`.
-            unsafe {
-                std::env::set_var("SSH_AUTH_SOCK", &auth_sock);
-            }
-
-            Self {
-                auth_sock,
-                pid,
-                previous_auth_sock,
-            }
-        }
-    }
-
-    #[cfg(unix)]
-    impl Drop for TestSshAgent {
-        fn drop(&mut self) {
-            use std::process::Command;
-
-            // SAFETY: agent tests serialize access with `SSH_AGENT_ENV_LOCK`.
-            unsafe {
-                if let Some(previous_auth_sock) = self.previous_auth_sock.as_ref() {
-                    std::env::set_var("SSH_AUTH_SOCK", previous_auth_sock);
-                } else {
-                    std::env::remove_var("SSH_AUTH_SOCK");
-                }
-            }
-            let _ = Command::new("kill").arg(&self.pid).status();
-        }
-    }
 
     fn test_runtime() -> Arc<Runtime> {
         Arc::new(
@@ -1742,8 +1759,11 @@ mod test {
         let server_key = PublicKeyOrCertificate::Certificate(certificate);
         let runtime = test_runtime();
 
-        let mut rejected =
-            CaSignaturePolicyHandler::new(NoCheckServerKey, vec!["rsa-sha2-256".to_string()]);
+        let mut rejected = CaSignaturePolicyHandler::new(
+            NoCheckServerKey,
+            vec!["rsa-sha2-256".to_string()],
+            false,
+        );
         assert!(
             !runtime
                 .block_on(rejected.check_server_key(&server_key))
@@ -1751,7 +1771,7 @@ mod test {
         );
 
         let mut accepted =
-            CaSignaturePolicyHandler::new(NoCheckServerKey, vec!["ssh-ed25519".to_string()]);
+            CaSignaturePolicyHandler::new(NoCheckServerKey, vec!["ssh-ed25519".to_string()], false);
         assert!(
             runtime
                 .block_on(accepted.check_server_key(&server_key))
@@ -2041,29 +2061,15 @@ mod test {
     #[test]
     #[cfg(unix)]
     fn should_connect_to_ssh_server_auth_ssh_agent() {
-        use std::process::Command;
-
         use crate::SshAgentIdentity;
         use crate::ssh::container::OpensshServer;
 
         crate::mock::logger();
-        let _env_lock = SSH_AGENT_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let agent = TestSshAgent::start();
+        let agent = ssh_mock::TestSshAgent::start();
 
         let key_file = ssh_mock::create_key_file();
         // ssh-add refuses keys with loose permissions.
-        Command::new("chmod")
-            .args(["600", &key_file.path().display().to_string()])
-            .status()
-            .expect("chmod failed");
-        let added = Command::new("ssh-add")
-            .arg(key_file.path())
-            .env("SSH_AUTH_SOCK", &agent.auth_sock)
-            .status()
-            .expect("ssh-add failed to run");
-        assert!(added.success(), "ssh-add could not load the mock key");
+        agent.add_key(key_file.path());
 
         // Point the russh agent client at our agent. No key storage, no password:
         // authentication must succeed through the agent alone.
@@ -2088,10 +2094,7 @@ mod test {
 
         use crate::ssh::container::OpensshServer;
 
-        let _env_lock = SSH_AGENT_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let agent = TestSshAgent::start();
+        let agent = ssh_mock::TestSshAgent::start();
         let container = OpensshServer::start();
         // This Ed25519 key is not authorized by the server. OpenSSH still adds a
         // file key to the agent when it is loaded, before password fallback.
@@ -2116,7 +2119,7 @@ mod test {
         let identities = runtime
             .block_on(async {
                 let mut client =
-                    russh::keys::agent::client::AgentClient::connect_uds(&agent.auth_sock).await?;
+                    russh::keys::agent::client::AgentClient::connect_uds(agent.auth_sock()).await?;
                 client.request_identities().await
             })
             .expect("failed to list agent identities");
@@ -2131,16 +2134,6 @@ mod test {
                 .fingerprint(russh::keys::HashAlg::Sha256)
                 == expected_key
         }));
-    }
-
-    /// Parse a `NAME=value;` assignment from `ssh-agent -s` output.
-    #[cfg(unix)]
-    fn parse_agent_var(output: &str, name: &str) -> Option<String> {
-        let needle = format!("{name}=");
-        let start = output.find(&needle)? + needle.len();
-        let rest = &output[start..];
-        let end = rest.find(';')?;
-        Some(rest[..end].to_string())
     }
 
     #[test]
@@ -2158,6 +2151,35 @@ mod test {
         let mut session = RusshSession::<NoCheckServerKey>::connect(&opts).unwrap();
         assert!(session.authenticated().unwrap());
         assert!(session.cmd("pwd").is_ok());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn should_forward_configured_ssh_agent() {
+        let agent = ssh_mock::TestSshAgent::start();
+        let key_file = ssh_mock::create_key_file();
+        agent.add_key(key_file.path());
+        let container = crate::ssh::container::OpensshServer::start();
+        let mut config_file = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            config_file,
+            "Host forwarded\n    HostName 127.0.0.1\n    Port {port}\n    User sftp\n    ForwardAgent yes",
+            port = container.port(),
+        )
+        .expect("failed to write SSH config");
+        let runtime = test_runtime();
+        let opts = SshOpts::new("forwarded")
+            .config_file(config_file.path(), ParseRule::STRICT)
+            .password("password")
+            .runtime(runtime);
+        let mut session =
+            RusshSession::<NoCheckServerKey>::connect(&opts).expect("failed to connect");
+
+        let (status, output) = session
+            .cmd("ssh-add -L")
+            .expect("failed to query remote agent");
+        assert_eq!(status, 0, "remote ssh-add failed: {output}");
+        assert!(output.contains("ssh-rsa"));
     }
 
     #[test]

--- a/src/ssh/backend/russh.rs
+++ b/src/ssh/backend/russh.rs
@@ -712,7 +712,13 @@ where
 }
 
 fn russh_client_config(opts: &SshOpts, ssh_config: &Config) -> Arc<client::Config> {
-    let mut config = client::Config::default();
+    let mut config = client::Config {
+        keepalive_interval: ssh_config
+            .params
+            .server_alive_interval
+            .filter(|interval| !interval.is_zero()),
+        ..client::Config::default()
+    };
     apply_config_algo_prefs(&mut config, ssh_config);
     apply_opts_algo_prefs(&mut config, opts);
     Arc::new(config)
@@ -2245,6 +2251,34 @@ mod test {
         );
         drop(stream);
         server.join().expect("test server panicked");
+    }
+
+    #[test]
+    fn should_apply_configured_server_alive_interval() {
+        let mut config_file = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(config_file, "Host keepalive\n    ServerAliveInterval 17")
+            .expect("failed to write SSH config");
+        let opts = SshOpts::new("keepalive")
+            .config_file(config_file.path(), ParseRule::STRICT)
+            .runtime(test_runtime());
+        let ssh_config = Config::try_from(&opts).expect("failed to parse SSH config");
+
+        assert_eq!(
+            russh_client_config(&opts, &ssh_config).keepalive_interval,
+            Some(Duration::from_secs(17))
+        );
+
+        let mut config_file = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(config_file, "Host keepalive\n    ServerAliveInterval 0")
+            .expect("failed to write SSH config");
+        let opts = SshOpts::new("keepalive")
+            .config_file(config_file.path(), ParseRule::STRICT)
+            .runtime(test_runtime());
+        let ssh_config = Config::try_from(&opts).expect("failed to parse SSH config");
+        assert_eq!(
+            russh_client_config(&opts, &ssh_config).keepalive_interval,
+            None
+        );
     }
 
     #[test]

--- a/src/ssh/backend/russh.rs
+++ b/src/ssh/backend/russh.rs
@@ -14,9 +14,9 @@ use std::task::{Context, Poll};
 
 use remotefs::fs::{Metadata, ReadStream, WriteStream};
 use remotefs::{File, RemoteError, RemoteErrorType, RemoteResult};
-use russh::client::{Handle, Handler};
-use russh::keys::{Algorithm, PublicKeyOrCertificate};
-use russh::{Disconnect, client};
+use russh::client::{ChannelOpenHandle, DisconnectReason, Handle, Handler, Msg, Session};
+use russh::keys::{Algorithm, PublicKey, PublicKeyOrCertificate};
+use russh::{Channel, ChannelId, ChannelOpenFailure, Disconnect, Sig, client};
 use russh_sftp::client::SftpSession;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::{TcpSocket, TcpStream};
@@ -49,13 +49,328 @@ impl Handler for NoCheckServerKey {
     }
 }
 
+/// Transparent handler wrapper enforcing configured CA signature algorithms.
+struct CaSignaturePolicyHandler<T> {
+    inner: T,
+    allowed_algorithms: Vec<String>,
+}
+
+impl<T> CaSignaturePolicyHandler<T> {
+    fn new(inner: T, allowed_algorithms: Vec<String>) -> Self {
+        Self {
+            inner,
+            allowed_algorithms,
+        }
+    }
+}
+
+impl<T> Handler for CaSignaturePolicyHandler<T>
+where
+    T: Handler,
+{
+    type Error = T::Error;
+
+    fn auth_banner(
+        &mut self,
+        banner: &str,
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.auth_banner(banner, session)
+    }
+
+    async fn check_server_key(
+        &mut self,
+        server_public_key: &PublicKeyOrCertificate,
+    ) -> Result<bool, Self::Error> {
+        if let PublicKeyOrCertificate::Certificate(certificate) = server_public_key {
+            let signature_algorithm = certificate.signature().algorithm();
+            if !self
+                .allowed_algorithms
+                .iter()
+                .any(|allowed| allowed == signature_algorithm.as_ref())
+            {
+                return Ok(false);
+            }
+        }
+        self.inner.check_server_key(server_public_key).await
+    }
+
+    fn kex_done(
+        &mut self,
+        shared_secret: Option<&[u8]>,
+        names: &russh::Names,
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.kex_done(shared_secret, names, session)
+    }
+
+    fn channel_open_confirmation(
+        &mut self,
+        id: ChannelId,
+        max_packet_size: u32,
+        window_size: u32,
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner
+            .channel_open_confirmation(id, max_packet_size, window_size, session)
+    }
+
+    fn channel_success(
+        &mut self,
+        channel: ChannelId,
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.channel_success(channel, session)
+    }
+
+    fn channel_failure(
+        &mut self,
+        channel: ChannelId,
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.channel_failure(channel, session)
+    }
+
+    fn channel_close(
+        &mut self,
+        channel: ChannelId,
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.channel_close(channel, session)
+    }
+
+    fn channel_eof(
+        &mut self,
+        channel: ChannelId,
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.channel_eof(channel, session)
+    }
+
+    fn channel_open_failure(
+        &mut self,
+        channel: ChannelId,
+        reason: ChannelOpenFailure,
+        description: &str,
+        language: &str,
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner
+            .channel_open_failure(channel, reason, description, language, session)
+    }
+
+    fn server_channel_open_forwarded_tcpip(
+        &mut self,
+        channel: Channel<Msg>,
+        connected_address: &str,
+        connected_port: u32,
+        originator_address: &str,
+        originator_port: u32,
+        reply: ChannelOpenHandle,
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.server_channel_open_forwarded_tcpip(
+            channel,
+            connected_address,
+            connected_port,
+            originator_address,
+            originator_port,
+            reply,
+            session,
+        )
+    }
+
+    fn server_channel_open_forwarded_streamlocal(
+        &mut self,
+        channel: Channel<Msg>,
+        socket_path: &str,
+        reply: ChannelOpenHandle,
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner
+            .server_channel_open_forwarded_streamlocal(channel, socket_path, reply, session)
+    }
+
+    fn server_channel_open_agent_forward(
+        &mut self,
+        channel: Channel<Msg>,
+        reply: ChannelOpenHandle,
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner
+            .server_channel_open_agent_forward(channel, reply, session)
+    }
+
+    fn should_accept_unknown_server_channel(
+        &mut self,
+        id: ChannelId,
+        channel_type: &str,
+    ) -> impl Future<Output = bool> + Send {
+        self.inner
+            .should_accept_unknown_server_channel(id, channel_type)
+    }
+
+    fn server_channel_open_unknown(
+        &mut self,
+        channel: Channel<Msg>,
+        reply: ChannelOpenHandle,
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner
+            .server_channel_open_unknown(channel, reply, session)
+    }
+
+    fn server_channel_open_session(
+        &mut self,
+        channel: Channel<Msg>,
+        reply: ChannelOpenHandle,
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner
+            .server_channel_open_session(channel, reply, session)
+    }
+
+    fn server_channel_open_direct_tcpip(
+        &mut self,
+        channel: Channel<Msg>,
+        host_to_connect: &str,
+        port_to_connect: u32,
+        originator_address: &str,
+        originator_port: u32,
+        reply: ChannelOpenHandle,
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.server_channel_open_direct_tcpip(
+            channel,
+            host_to_connect,
+            port_to_connect,
+            originator_address,
+            originator_port,
+            reply,
+            session,
+        )
+    }
+
+    fn server_channel_open_direct_streamlocal(
+        &mut self,
+        channel: Channel<Msg>,
+        socket_path: &str,
+        reply: ChannelOpenHandle,
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner
+            .server_channel_open_direct_streamlocal(channel, socket_path, reply, session)
+    }
+
+    fn server_channel_open_x11(
+        &mut self,
+        channel: Channel<Msg>,
+        originator_address: &str,
+        originator_port: u32,
+        reply: ChannelOpenHandle,
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.server_channel_open_x11(
+            channel,
+            originator_address,
+            originator_port,
+            reply,
+            session,
+        )
+    }
+
+    fn data(
+        &mut self,
+        channel: ChannelId,
+        data: &[u8],
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.data(channel, data, session)
+    }
+
+    fn extended_data(
+        &mut self,
+        channel: ChannelId,
+        ext: u32,
+        data: &[u8],
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.extended_data(channel, ext, data, session)
+    }
+
+    fn xon_xoff(
+        &mut self,
+        channel: ChannelId,
+        client_can_do: bool,
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.xon_xoff(channel, client_can_do, session)
+    }
+
+    fn exit_status(
+        &mut self,
+        channel: ChannelId,
+        exit_status: u32,
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.exit_status(channel, exit_status, session)
+    }
+
+    fn exit_signal(
+        &mut self,
+        channel: ChannelId,
+        signal_name: Sig,
+        core_dumped: bool,
+        error_message: &str,
+        lang_tag: &str,
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.exit_signal(
+            channel,
+            signal_name,
+            core_dumped,
+            error_message,
+            lang_tag,
+            session,
+        )
+    }
+
+    fn window_adjusted(
+        &mut self,
+        channel: ChannelId,
+        new_size: u32,
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.window_adjusted(channel, new_size, session)
+    }
+
+    fn adjust_window(&mut self, channel: ChannelId, window: u32) -> u32 {
+        self.inner.adjust_window(channel, window)
+    }
+
+    fn openssh_ext_host_keys_announced(
+        &mut self,
+        keys: Vec<PublicKey>,
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.openssh_ext_host_keys_announced(keys, session)
+    }
+
+    fn disconnected(
+        &mut self,
+        reason: DisconnectReason<Self::Error>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.disconnected(reason)
+    }
+}
+
 /// [`russh`](https://docs.rs/russh/latest/russh) session.
 pub struct RusshSession<T>
 where
     T: Handler + Default + Send + 'static,
 {
     runtime: Arc<Runtime>,
-    session: Handle<T>,
+    session: Handle<CaSignaturePolicyHandler<T>>,
 }
 
 /// SFTP handle for russh.
@@ -143,24 +458,34 @@ impl AsyncWrite for ConnectionDeadlineStream {
     }
 }
 
+struct ConnectionTarget<'a> {
+    address: &'a str,
+    bind_address: Option<&'a str>,
+    bind_interface: Option<&'a str>,
+}
+
 fn connect_with_timeout<T>(
     runtime: &Runtime,
     config: Arc<client::Config>,
-    address: &str,
-    bind_address: Option<&str>,
-    bind_interface: Option<&str>,
+    handler: T,
+    target: ConnectionTarget<'_>,
     tcp_keep_alive: Option<bool>,
     timeout: std::time::Duration,
 ) -> RemoteResult<Handle<T>>
 where
-    T: Handler + Default + Send + 'static,
+    T: Handler + Send + 'static,
 {
     let deadline = Instant::now() + timeout;
     let stream = runtime
         .block_on(async {
             tokio::time::timeout_at(
                 deadline,
-                connect_tcp(address, bind_address, bind_interface, tcp_keep_alive),
+                connect_tcp(
+                    target.address,
+                    target.bind_address,
+                    target.bind_interface,
+                    tcp_keep_alive,
+                ),
             )
             .await
         })
@@ -184,7 +509,7 @@ where
     let connection_deadline_active = deadline_active.clone();
     let session_result = runtime.block_on(async {
         let stream = ConnectionDeadlineStream::new(stream, deadline, connection_deadline_active);
-        client::connect_stream(config, stream, T::default()).await
+        client::connect_stream(config, stream, handler).await
     });
     deadline_active.store(false, Ordering::Release);
     session_result.map_err(|err| {
@@ -289,14 +614,24 @@ where
 
         let config = Arc::new(config);
         let connection_attempts = ssh_config.connection_attempts.max(1);
+        let ca_signature_algorithms = ssh_config
+            .params
+            .ca_signature_algorithms
+            .algorithms()
+            .to_vec();
         let mut attempt = 1;
         let mut session = loop {
-            match connect_with_timeout::<T>(
+            let handler =
+                CaSignaturePolicyHandler::new(T::default(), ca_signature_algorithms.clone());
+            match connect_with_timeout(
                 &runtime,
                 config.clone(),
-                &ssh_config.address,
-                ssh_config.params.bind_address.as_deref(),
-                ssh_config.params.bind_interface.as_deref(),
+                handler,
+                ConnectionTarget {
+                    address: &ssh_config.address,
+                    bind_address: ssh_config.params.bind_address.as_deref(),
+                    bind_interface: ssh_config.params.bind_interface.as_deref(),
+                },
                 ssh_config.params.tcp_keep_alive,
                 ssh_config.connection_timeout,
             ) {
@@ -1256,6 +1591,30 @@ mod test {
                 .build()
                 .unwrap(),
         )
+    }
+
+    #[test]
+    fn should_apply_ca_signature_algorithms_to_host_certificates() {
+        let certificate = russh::keys::Certificate::from_openssh(ssh_mock::MOCK_USER_CERTIFICATE)
+            .expect("failed to parse test certificate");
+        let server_key = PublicKeyOrCertificate::Certificate(certificate);
+        let runtime = test_runtime();
+
+        let mut rejected =
+            CaSignaturePolicyHandler::new(NoCheckServerKey, vec!["rsa-sha2-256".to_string()]);
+        assert!(
+            !runtime
+                .block_on(rejected.check_server_key(&server_key))
+                .expect("failed to check rejected certificate")
+        );
+
+        let mut accepted =
+            CaSignaturePolicyHandler::new(NoCheckServerKey, vec!["ssh-ed25519".to_string()]);
+        assert!(
+            runtime
+                .block_on(accepted.check_server_key(&server_key))
+                .expect("failed to check accepted certificate")
+        );
     }
 
     #[test]

--- a/src/ssh/backend/russh/auth.rs
+++ b/src/ssh/backend/russh/auth.rs
@@ -20,6 +20,13 @@ enum Authentication {
     Password(String),
 }
 
+struct KeyAuthenticationOptions<'a> {
+    certificate_path: Option<&'a Path>,
+    passphrase: Option<&'a str>,
+    accepted_algorithms: &'a [String],
+    add_to_agent: bool,
+}
+
 /// Local private-key signer for russh's hash-selecting certificate API.
 struct PrivateKeySigner {
     private_key: Arc<russh::keys::PrivateKey>,
@@ -133,9 +140,15 @@ where
                     runtime,
                     username,
                     &key_path,
-                    certificate.as_deref(),
-                    opts.password.as_deref(),
-                    ssh_config.params.pubkey_accepted_algorithms.algorithms(),
+                    KeyAuthenticationOptions {
+                        certificate_path: certificate.as_deref(),
+                        passphrase: opts.password.as_deref(),
+                        accepted_algorithms: ssh_config
+                            .params
+                            .pubkey_accepted_algorithms
+                            .algorithms(),
+                        add_to_agent: ssh_config.params.add_keys_to_agent.unwrap_or(false),
+                    },
                 ) {
                     Ok(()) => {
                         info!("Authenticated with key at '{}'", key_path.display());
@@ -236,9 +249,7 @@ fn auth_with_rsa_key<T>(
     runtime: &Runtime,
     username: &str,
     key_path: &Path,
-    certificate_path: Option<&Path>,
-    passphrase: Option<&str>,
-    accepted_algorithms: &[String],
+    options: KeyAuthenticationOptions<'_>,
 ) -> RemoteResult<()>
 where
     T: Handler,
@@ -248,18 +259,20 @@ where
         key_path.display()
     );
 
-    let private_key = russh::keys::load_secret_key(key_path, passphrase).map_err(|err| {
-        RemoteError::new_ex(
-            RemoteErrorType::AuthenticationFailed,
-            format!(
-                "Could not load private key at '{}': {err}",
-                key_path.display()
-            ),
-        )
-    })?;
+    let private_key =
+        russh::keys::load_secret_key(key_path, options.passphrase).map_err(|err| {
+            RemoteError::new_ex(
+                RemoteErrorType::AuthenticationFailed,
+                format!(
+                    "Could not load private key at '{}': {err}",
+                    key_path.display()
+                ),
+            )
+        })?;
     let private_key = Arc::new(private_key);
+    maybe_add_key_to_agent(runtime, private_key.as_ref(), options.add_to_agent);
 
-    if let Some(certificate_path) = certificate_path {
+    if let Some(certificate_path) = options.certificate_path {
         let certificate =
             russh::keys::load_openssh_certificate(certificate_path).map_err(|err| {
                 RemoteError::new_ex(
@@ -271,7 +284,7 @@ where
                 )
             })?;
         let hash_algs =
-            accepted_hash_algorithms(&certificate.algorithm(), accepted_algorithms, true);
+            accepted_hash_algorithms(&certificate.algorithm(), options.accepted_algorithms, true);
         if hash_algs.is_empty() {
             return Err(RemoteError::new_ex(
                 RemoteErrorType::AuthenticationFailed,
@@ -323,7 +336,7 @@ where
     }
 
     let key_algorithm = private_key.algorithm();
-    let hash_algs = accepted_hash_algorithms(&key_algorithm, accepted_algorithms, false);
+    let hash_algs = accepted_hash_algorithms(&key_algorithm, options.accepted_algorithms, false);
     if hash_algs.is_empty() {
         return Err(RemoteError::new_ex(
             RemoteErrorType::AuthenticationFailed,
@@ -369,6 +382,47 @@ where
             "public key authentication failed for key at '{}' (remaining methods: {last_failure:?})",
             key_path.display()
         ),
+    ))
+}
+
+fn maybe_add_key_to_agent(
+    runtime: &Runtime,
+    private_key: &russh::keys::PrivateKey,
+    add_to_agent: bool,
+) {
+    if add_to_agent && let Err(err) = add_key_to_agent(runtime, private_key) {
+        warn!("Could not add loaded key to SSH agent: {err}");
+    }
+}
+
+#[cfg(unix)]
+fn add_key_to_agent(runtime: &Runtime, private_key: &russh::keys::PrivateKey) -> RemoteResult<()> {
+    use russh::keys::agent::client::AgentClient;
+
+    runtime.block_on(async {
+        let mut agent = AgentClient::connect_env().await.map_err(|err| {
+            RemoteError::new_ex(
+                RemoteErrorType::ConnectionError,
+                format!("could not connect to SSH agent: {err}"),
+            )
+        })?;
+        agent.add_identity(private_key, &[]).await.map_err(|err| {
+            RemoteError::new_ex(
+                RemoteErrorType::ProtocolError,
+                format!("could not add identity to SSH agent: {err}"),
+            )
+        })
+    })
+}
+
+#[cfg(not(unix))]
+fn add_key_to_agent(
+    _runtime: &Runtime,
+    _private_key: &russh::keys::PrivateKey,
+) -> RemoteResult<()> {
+    Err(RemoteError::new_ex(
+        RemoteErrorType::UnsupportedFeature,
+        "adding identities to the SSH agent is not supported on this platform",
     ))
 }
 

--- a/src/ssh/backend/russh/auth.rs
+++ b/src/ssh/backend/russh/auth.rs
@@ -13,8 +13,50 @@ use crate::ssh::config::Config;
 /// Authentication method for russh backend.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Authentication {
-    RsaKey(PathBuf),
+    RsaKey {
+        private_key: PathBuf,
+        certificate: Option<PathBuf>,
+    },
     Password(String),
+}
+
+/// Local private-key signer for russh's hash-selecting certificate API.
+struct PrivateKeySigner {
+    private_key: Arc<russh::keys::PrivateKey>,
+}
+
+#[derive(Debug)]
+struct PrivateKeySignerError(String);
+
+impl std::fmt::Display for PrivateKeySignerError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for PrivateKeySignerError {}
+
+impl From<russh::SendError> for PrivateKeySignerError {
+    fn from(err: russh::SendError) -> Self {
+        Self(err.to_string())
+    }
+}
+
+impl russh::Signer for PrivateKeySigner {
+    type Error = PrivateKeySignerError;
+
+    fn auth_sign(
+        &mut self,
+        _key: &russh::keys::agent::AgentIdentity,
+        hash_alg: Option<russh::keys::HashAlg>,
+        to_sign: Vec<u8>,
+    ) -> impl std::future::Future<Output = Result<Vec<u8>, Self::Error>> + Send {
+        std::future::ready(sign_with_private_key(
+            self.private_key.as_ref(),
+            hash_alg,
+            to_sign,
+        ))
+    }
 }
 
 /// Authenticate a russh session using the configured methods.
@@ -58,13 +100,19 @@ where
             x.resolve(ssh_config.host.as_str(), username.as_str())
                 .or(x.resolve(ssh_config.resolved_host.as_str(), username.as_str()))
         }) {
-            methods.push(Authentication::RsaKey(rsa_key.clone()));
+            methods.push(Authentication::RsaKey {
+                private_key: rsa_key.clone(),
+                certificate: ssh_config.params.certificate_file.clone(),
+            });
         }
 
         // Add identity files from config
         if let Some(identity_files) = ssh_config.params.identity_file.as_ref() {
             for identity_file in identity_files {
-                methods.push(Authentication::RsaKey(identity_file.clone()));
+                methods.push(Authentication::RsaKey {
+                    private_key: identity_file.clone(),
+                    certificate: ssh_config.params.certificate_file.clone(),
+                });
             }
         }
     }
@@ -76,12 +124,16 @@ where
     let mut last_err = None;
     for auth_method in methods {
         match auth_method {
-            Authentication::RsaKey(key_path) => {
+            Authentication::RsaKey {
+                private_key: key_path,
+                certificate,
+            } => {
                 match auth_with_rsa_key(
                     session,
                     runtime,
                     username,
                     &key_path,
+                    certificate.as_deref(),
                     opts.password.as_deref(),
                     ssh_config.params.pubkey_accepted_algorithms.algorithms(),
                 ) {
@@ -131,12 +183,10 @@ fn accepted_hash_algorithms(
         accepted_algorithms
             .iter()
             .filter_map(|algorithm| match (certificate, algorithm.as_str()) {
-                (false, "rsa-sha2-512") | (true, "rsa-sha2-512-cert-v01@openssh.com") => {
-                    Some(Some(russh::keys::HashAlg::Sha512))
-                }
-                (false, "rsa-sha2-256") | (true, "rsa-sha2-256-cert-v01@openssh.com") => {
-                    Some(Some(russh::keys::HashAlg::Sha256))
-                }
+                (false, "rsa-sha2-512") => Some(Some(russh::keys::HashAlg::Sha512)),
+                (false, "rsa-sha2-256") => Some(Some(russh::keys::HashAlg::Sha256)),
+                // russh 0.63 always advertises a certificate's embedded
+                // `ssh-rsa-cert` name and cannot advertise its SHA-2 variants.
                 (false, "ssh-rsa") | (true, "ssh-rsa-cert-v01@openssh.com") => Some(None),
                 _ => None,
             })
@@ -154,12 +204,39 @@ fn accepted_hash_algorithms(
     }
 }
 
+/// Append an SSH signature using the selected RSA hash when applicable.
+fn sign_with_private_key(
+    private_key: &russh::keys::PrivateKey,
+    hash_alg: Option<russh::keys::HashAlg>,
+    mut to_sign: Vec<u8>,
+) -> Result<Vec<u8>, PrivateKeySignerError> {
+    use russh::keys::signature::Signer as _;
+    use russh::keys::ssh_encoding::Encode as _;
+
+    let signature = match private_key.key_data() {
+        russh::keys::ssh_key::private::KeypairData::Rsa(keypair) => {
+            (keypair, hash_alg).try_sign(&to_sign)
+        }
+        _ => private_key.try_sign(&to_sign),
+    }
+    .map_err(|err| PrivateKeySignerError(err.to_string()))?;
+    let mut encoded_signature = Vec::new();
+    signature
+        .encode(&mut encoded_signature)
+        .map_err(|err| PrivateKeySignerError(err.to_string()))?;
+    encoded_signature
+        .encode(&mut to_sign)
+        .map_err(|err| PrivateKeySignerError(err.to_string()))?;
+    Ok(to_sign)
+}
+
 /// Authenticate with an RSA private key file.
 fn auth_with_rsa_key<T>(
     session: &mut Handle<T>,
     runtime: &Runtime,
     username: &str,
     key_path: &Path,
+    certificate_path: Option<&Path>,
     passphrase: Option<&str>,
     accepted_algorithms: &[String],
 ) -> RemoteResult<()>
@@ -181,6 +258,69 @@ where
         )
     })?;
     let private_key = Arc::new(private_key);
+
+    if let Some(certificate_path) = certificate_path {
+        let certificate =
+            russh::keys::load_openssh_certificate(certificate_path).map_err(|err| {
+                RemoteError::new_ex(
+                    RemoteErrorType::AuthenticationFailed,
+                    format!(
+                        "Could not load certificate at '{}': {err}",
+                        certificate_path.display()
+                    ),
+                )
+            })?;
+        let hash_algs =
+            accepted_hash_algorithms(&certificate.algorithm(), accepted_algorithms, true);
+        if hash_algs.is_empty() {
+            return Err(RemoteError::new_ex(
+                RemoteErrorType::AuthenticationFailed,
+                format!(
+                    "certificate algorithm {} is not accepted by SSH config",
+                    certificate.algorithm().to_certificate_type()
+                ),
+            ));
+        }
+
+        let mut signer = PrivateKeySigner {
+            private_key: private_key.clone(),
+        };
+        let mut last_failure = None;
+        for hash_alg in hash_algs {
+            let auth_result = runtime
+                .block_on(async {
+                    session
+                        .authenticate_certificate_with(
+                            username,
+                            certificate.clone(),
+                            hash_alg,
+                            &mut signer,
+                        )
+                        .await
+                })
+                .map_err(|err| RemoteError::new_ex(RemoteErrorType::AuthenticationFailed, err))?;
+            match auth_result {
+                russh::client::AuthResult::Success => return Ok(()),
+                russh::client::AuthResult::Failure {
+                    remaining_methods, ..
+                } => {
+                    let pubkey_still_offered =
+                        remaining_methods.contains(&russh::MethodKind::PublicKey);
+                    last_failure = Some(remaining_methods);
+                    if !pubkey_still_offered {
+                        break;
+                    }
+                }
+            }
+        }
+        return Err(RemoteError::new_ex(
+            RemoteErrorType::AuthenticationFailed,
+            format!(
+                "certificate authentication failed for key at '{}' (remaining methods: {last_failure:?})",
+                key_path.display()
+            ),
+        ));
+    }
 
     let key_algorithm = private_key.algorithm();
     let hash_algs = accepted_hash_algorithms(&key_algorithm, accepted_algorithms, false);
@@ -380,6 +520,7 @@ where
 mod tests {
 
     use super::*;
+    use crate::mock::ssh as ssh_mock;
 
     #[test]
     fn should_distinguish_plain_and_certificate_agent_algorithms() {
@@ -387,20 +528,45 @@ mod tests {
         let ed25519 = russh::keys::Algorithm::Ed25519;
         let plain = vec!["rsa-sha2-256".to_string()];
         let certificate = vec!["rsa-sha2-256-cert-v01@openssh.com".to_string()];
+        let legacy_certificate = vec!["ssh-rsa-cert-v01@openssh.com".to_string()];
         let ed25519_plain = vec!["ssh-ed25519".to_string()];
         let ed25519_certificate = vec!["ssh-ed25519-cert-v01@openssh.com".to_string()];
 
         assert!(accepted_hash_algorithms(&rsa, &plain, true).is_empty());
         assert!(accepted_hash_algorithms(&rsa, &certificate, false).is_empty());
+        assert!(accepted_hash_algorithms(&rsa, &certificate, true).is_empty());
         assert_eq!(
-            accepted_hash_algorithms(&rsa, &certificate, true),
-            vec![Some(russh::keys::HashAlg::Sha256)]
+            accepted_hash_algorithms(&rsa, &legacy_certificate, true),
+            vec![None]
         );
         assert!(accepted_hash_algorithms(&ed25519, &ed25519_plain, true).is_empty());
         assert!(accepted_hash_algorithms(&ed25519, &ed25519_certificate, false).is_empty());
         assert_eq!(
             accepted_hash_algorithms(&ed25519, &ed25519_certificate, true),
             vec![None]
+        );
+    }
+
+    #[test]
+    fn should_sign_legacy_rsa_certificate_with_ssh_rsa() {
+        let key_file = ssh_mock::create_key_file();
+        let private_key =
+            russh::keys::load_secret_key(key_file.path(), None).expect("failed to load RSA key");
+        let message = b"certificate authentication payload".to_vec();
+
+        let signed = sign_with_private_key(&private_key, None, message.clone())
+            .expect("failed to sign certificate authentication payload");
+        let algorithm_length_offset = message.len() + 4;
+        let algorithm_offset = algorithm_length_offset + 4;
+        let algorithm_length = u32::from_be_bytes(
+            signed[algorithm_length_offset..algorithm_offset]
+                .try_into()
+                .expect("signature algorithm length must be four bytes"),
+        ) as usize;
+
+        assert_eq!(
+            &signed[algorithm_offset..algorithm_offset + algorithm_length],
+            b"ssh-rsa"
         );
     }
 }

--- a/src/ssh/backend/russh/auth.rs
+++ b/src/ssh/backend/russh/auth.rs
@@ -28,10 +28,11 @@ where
     T: Handler,
 {
     let username = &ssh_config.username;
+    let pubkey_authentication = ssh_config.params.pubkey_authentication.unwrap_or(true);
 
     // Authentication order mirrors the libssh2/libssh backends: SSH agent first,
     // then key, then password.
-    if let Some(agent_identity) = opts.ssh_agent_identity.as_ref() {
+    if pubkey_authentication && let Some(agent_identity) = opts.ssh_agent_identity.as_ref() {
         match auth_with_agent(session, runtime, username, agent_identity) {
             Ok(()) => {
                 info!("Authenticated with ssh agent");
@@ -46,17 +47,19 @@ where
     // Collect authentication methods in priority order: RSA key, then password
     let mut methods = vec![];
 
-    if let Some(rsa_key) = opts.key_storage.as_ref().and_then(|x| {
-        x.resolve(ssh_config.host.as_str(), username.as_str())
-            .or(x.resolve(ssh_config.resolved_host.as_str(), username.as_str()))
-    }) {
-        methods.push(Authentication::RsaKey(rsa_key.clone()));
-    }
+    if pubkey_authentication {
+        if let Some(rsa_key) = opts.key_storage.as_ref().and_then(|x| {
+            x.resolve(ssh_config.host.as_str(), username.as_str())
+                .or(x.resolve(ssh_config.resolved_host.as_str(), username.as_str()))
+        }) {
+            methods.push(Authentication::RsaKey(rsa_key.clone()));
+        }
 
-    // Add identity files from config
-    if let Some(identity_files) = ssh_config.params.identity_file.as_ref() {
-        for identity_file in identity_files {
-            methods.push(Authentication::RsaKey(identity_file.clone()));
+        // Add identity files from config
+        if let Some(identity_files) = ssh_config.params.identity_file.as_ref() {
+            for identity_file in identity_files {
+                methods.push(Authentication::RsaKey(identity_file.clone()));
+            }
         }
     }
 

--- a/src/ssh/backend/russh/auth.rs
+++ b/src/ssh/backend/russh/auth.rs
@@ -33,7 +33,13 @@ where
     // Authentication order mirrors the libssh2/libssh backends: SSH agent first,
     // then key, then password.
     if pubkey_authentication && let Some(agent_identity) = opts.ssh_agent_identity.as_ref() {
-        match auth_with_agent(session, runtime, username, agent_identity) {
+        match auth_with_agent(
+            session,
+            runtime,
+            username,
+            agent_identity,
+            ssh_config.params.pubkey_accepted_algorithms.algorithms(),
+        ) {
             Ok(()) => {
                 info!("Authenticated with ssh agent");
                 return Ok(());
@@ -77,6 +83,7 @@ where
                     username,
                     &key_path,
                     opts.password.as_deref(),
+                    ssh_config.params.pubkey_accepted_algorithms.algorithms(),
                 ) {
                     Ok(()) => {
                         info!("Authenticated with key at '{}'", key_path.display());
@@ -114,6 +121,39 @@ where
     }))
 }
 
+/// Return the configured signature hashes accepted for a public key algorithm.
+fn accepted_hash_algorithms(
+    key_algorithm: &russh::keys::Algorithm,
+    accepted_algorithms: &[String],
+    certificate: bool,
+) -> Vec<Option<russh::keys::HashAlg>> {
+    if matches!(key_algorithm, russh::keys::Algorithm::Rsa { .. }) {
+        accepted_algorithms
+            .iter()
+            .filter_map(|algorithm| match (certificate, algorithm.as_str()) {
+                (false, "rsa-sha2-512") | (true, "rsa-sha2-512-cert-v01@openssh.com") => {
+                    Some(Some(russh::keys::HashAlg::Sha512))
+                }
+                (false, "rsa-sha2-256") | (true, "rsa-sha2-256-cert-v01@openssh.com") => {
+                    Some(Some(russh::keys::HashAlg::Sha256))
+                }
+                (false, "ssh-rsa") | (true, "ssh-rsa-cert-v01@openssh.com") => Some(None),
+                _ => None,
+            })
+            .collect()
+    } else {
+        let key_algorithm = if certificate {
+            key_algorithm.to_certificate_type()
+        } else {
+            key_algorithm.as_ref().to_string()
+        };
+        if !accepted_algorithms.contains(&key_algorithm) {
+            return Vec::new();
+        }
+        vec![None]
+    }
+}
+
 /// Authenticate with an RSA private key file.
 fn auth_with_rsa_key<T>(
     session: &mut Handle<T>,
@@ -121,6 +161,7 @@ fn auth_with_rsa_key<T>(
     username: &str,
     key_path: &Path,
     passphrase: Option<&str>,
+    accepted_algorithms: &[String],
 ) -> RemoteResult<()>
 where
     T: Handler,
@@ -141,23 +182,18 @@ where
     })?;
     let private_key = Arc::new(private_key);
 
-    // For RSA keys, `None` maps to the legacy `ssh-rsa` (SHA-1) signature, which modern
-    // OpenSSH servers reject by default. Try the modern `rsa-sha2-512` / `rsa-sha2-256`
-    // signature algorithms first, falling back to SHA-1 for legacy servers.
-    // For non-RSA keys the hash is ignored, so a single `None` attempt is enough.
-    let hash_algs: &[Option<russh::keys::HashAlg>] = if private_key.algorithm().is_rsa() {
-        &[
-            Some(russh::keys::HashAlg::Sha512),
-            Some(russh::keys::HashAlg::Sha256),
-            None,
-        ]
-    } else {
-        &[None]
-    };
+    let key_algorithm = private_key.algorithm();
+    let hash_algs = accepted_hash_algorithms(&key_algorithm, accepted_algorithms, false);
+    if hash_algs.is_empty() {
+        return Err(RemoteError::new_ex(
+            RemoteErrorType::AuthenticationFailed,
+            format!("public key algorithm {key_algorithm} is not accepted by SSH config"),
+        ));
+    }
 
     let mut last_failure = None;
     for hash_alg in hash_algs {
-        let key_with_hash = russh::keys::PrivateKeyWithHashAlg::new(private_key.clone(), *hash_alg);
+        let key_with_hash = russh::keys::PrivateKeyWithHashAlg::new(private_key.clone(), hash_alg);
 
         let auth_result = runtime
             .block_on(async {
@@ -230,6 +266,7 @@ fn auth_with_agent<T>(
     runtime: &Runtime,
     username: &str,
     identity: &crate::SshAgentIdentity,
+    accepted_algorithms: &[String],
 ) -> RemoteResult<()>
 where
     T: Handler,
@@ -256,7 +293,16 @@ where
         let mut last_err = None;
         for agent_identity in identities {
             let pubkey = agent_identity.public_key().into_owned();
-            let blob = pubkey.to_bytes().unwrap_or_default();
+            let (blob, key_algorithm, certificate) = match &agent_identity {
+                russh::keys::agent::AgentIdentity::PublicKey { key, .. } => {
+                    (key.to_bytes().unwrap_or_default(), key.algorithm(), false)
+                }
+                russh::keys::agent::AgentIdentity::Certificate { certificate, .. } => (
+                    certificate.to_bytes().unwrap_or_default(),
+                    certificate.algorithm(),
+                    true,
+                ),
+            };
             if !identity.pubkey_matches(&blob) {
                 continue;
             }
@@ -265,23 +311,33 @@ where
                 pubkey.fingerprint(russh::keys::HashAlg::Sha256)
             );
 
-            // Same SHA-1 caveat as direct key auth: for RSA identities request the
-            // modern rsa-sha2-512/256 signature algorithms before the legacy ssh-rsa.
-            let hash_algs: &[Option<russh::keys::HashAlg>] = if pubkey.algorithm().is_rsa() {
-                &[
-                    Some(russh::keys::HashAlg::Sha512),
-                    Some(russh::keys::HashAlg::Sha256),
-                    None,
-                ]
-            } else {
-                &[None]
-            };
+            let hash_algs =
+                accepted_hash_algorithms(&key_algorithm, accepted_algorithms, certificate);
 
             for hash_alg in hash_algs {
-                match session
-                    .authenticate_publickey_with(username, pubkey.clone(), *hash_alg, &mut agent)
-                    .await
-                {
+                let auth_result = match &agent_identity {
+                    russh::keys::agent::AgentIdentity::PublicKey { key, .. } => {
+                        session
+                            .authenticate_publickey_with(
+                                username,
+                                key.clone(),
+                                hash_alg,
+                                &mut agent,
+                            )
+                            .await
+                    }
+                    russh::keys::agent::AgentIdentity::Certificate { certificate, .. } => {
+                        session
+                            .authenticate_certificate_with(
+                                username,
+                                certificate.clone(),
+                                hash_alg,
+                                &mut agent,
+                            )
+                            .await
+                    }
+                };
+                match auth_result {
                     Ok(russh::client::AuthResult::Success) => return Ok(()),
                     Ok(russh::client::AuthResult::Failure {
                         remaining_methods, ..
@@ -320,6 +376,35 @@ where
     })
 }
 
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn should_distinguish_plain_and_certificate_agent_algorithms() {
+        let rsa = russh::keys::Algorithm::Rsa { hash: None };
+        let ed25519 = russh::keys::Algorithm::Ed25519;
+        let plain = vec!["rsa-sha2-256".to_string()];
+        let certificate = vec!["rsa-sha2-256-cert-v01@openssh.com".to_string()];
+        let ed25519_plain = vec!["ssh-ed25519".to_string()];
+        let ed25519_certificate = vec!["ssh-ed25519-cert-v01@openssh.com".to_string()];
+
+        assert!(accepted_hash_algorithms(&rsa, &plain, true).is_empty());
+        assert!(accepted_hash_algorithms(&rsa, &certificate, false).is_empty());
+        assert_eq!(
+            accepted_hash_algorithms(&rsa, &certificate, true),
+            vec![Some(russh::keys::HashAlg::Sha256)]
+        );
+        assert!(accepted_hash_algorithms(&ed25519, &ed25519_plain, true).is_empty());
+        assert!(accepted_hash_algorithms(&ed25519, &ed25519_certificate, false).is_empty());
+        assert_eq!(
+            accepted_hash_algorithms(&ed25519, &ed25519_certificate, true),
+            vec![None]
+        );
+    }
+}
+
 /// The SSH agent is only reachable over a Unix socket; on other platforms this is a no-op
 /// that simply reports the agent as unavailable so the remaining methods are tried.
 #[cfg(not(unix))]
@@ -328,6 +413,7 @@ fn auth_with_agent<T>(
     _runtime: &Runtime,
     _username: &str,
     _identity: &crate::SshAgentIdentity,
+    _accepted_algorithms: &[String],
 ) -> RemoteResult<()>
 where
     T: Handler,

--- a/src/ssh/backend/russh/scp.rs
+++ b/src/ssh/backend/russh/scp.rs
@@ -22,12 +22,13 @@ fn shell_escape_arg(value: &str) -> String {
 pub(super) async fn recv<T>(
     session: &russh::client::Handle<T>,
     path: &Path,
+    forward_agent: bool,
 ) -> RemoteResult<Box<dyn std::io::Read + Send>>
 where
     T: Handler,
 {
     debug!("Opening channel for scp recv");
-    let mut channel = open_channel(session).await?;
+    let mut channel = open_channel(session, forward_agent).await?;
 
     let cmd = format!("scp -f {}", shell_escape_arg(&path.to_string_lossy()));
     channel.exec(true, cmd.as_bytes()).await.map_err(|err| {
@@ -107,12 +108,13 @@ pub(super) async fn send<T>(
     mode: i32,
     size: u64,
     runtime: Arc<Runtime>,
+    forward_agent: bool,
 ) -> RemoteResult<Box<dyn Write + Send>>
 where
     T: Handler,
 {
     debug!("Opening channel for scp send");
-    let mut channel = open_channel(session).await?;
+    let mut channel = open_channel(session, forward_agent).await?;
 
     let cmd = format!(
         "scp -t {}",

--- a/src/ssh/backend/socket.rs
+++ b/src/ssh/backend/socket.rs
@@ -1,0 +1,49 @@
+use std::io;
+use std::mem::ManuallyDrop;
+
+use socket2::Socket;
+
+#[cfg(unix)]
+#[cfg(test)]
+pub(super) fn keepalive(socket: &impl std::os::fd::AsRawFd) -> io::Result<bool> {
+    use std::os::fd::FromRawFd as _;
+
+    // SAFETY: `socket` owns this valid descriptor for the duration of the borrow, and
+    // `ManuallyDrop` prevents the temporary `Socket` from closing it.
+    let socket = ManuallyDrop::new(unsafe { Socket::from_raw_fd(socket.as_raw_fd()) });
+    socket.keepalive()
+}
+
+#[cfg(unix)]
+pub(super) fn set_keepalive(socket: &impl std::os::fd::AsRawFd, keepalive: bool) -> io::Result<()> {
+    use std::os::fd::FromRawFd as _;
+
+    // SAFETY: `socket` owns this valid descriptor for the duration of the borrow, and
+    // `ManuallyDrop` prevents the temporary `Socket` from closing it.
+    let socket = ManuallyDrop::new(unsafe { Socket::from_raw_fd(socket.as_raw_fd()) });
+    socket.set_keepalive(keepalive)
+}
+
+#[cfg(windows)]
+#[cfg(test)]
+pub(super) fn keepalive(socket: &impl std::os::windows::io::AsRawSocket) -> io::Result<bool> {
+    use std::os::windows::io::FromRawSocket as _;
+
+    // SAFETY: `socket` owns this valid handle for the duration of the borrow, and
+    // `ManuallyDrop` prevents the temporary `Socket` from closing it.
+    let socket = ManuallyDrop::new(unsafe { Socket::from_raw_socket(socket.as_raw_socket()) });
+    socket.keepalive()
+}
+
+#[cfg(windows)]
+pub(super) fn set_keepalive(
+    socket: &impl std::os::windows::io::AsRawSocket,
+    keepalive: bool,
+) -> io::Result<()> {
+    use std::os::windows::io::FromRawSocket as _;
+
+    // SAFETY: `socket` owns this valid handle for the duration of the borrow, and
+    // `ManuallyDrop` prevents the temporary `Socket` from closing it.
+    let socket = ManuallyDrop::new(unsafe { Socket::from_raw_socket(socket.as_raw_socket()) });
+    socket.set_keepalive(keepalive)
+}

--- a/src/ssh/config.rs
+++ b/src/ssh/config.rs
@@ -13,6 +13,7 @@ use ssh2_config::{DefaultAlgorithms, HostParams, ParseRule, SshConfig};
 use super::SshOpts;
 
 /// Ssh configuration params
+#[derive(Clone)]
 pub struct Config {
     pub params: HostParams,
     pub host: String,
@@ -20,6 +21,7 @@ pub struct Config {
     pub resolved_host: String,
     /// Address is host:port
     pub address: String,
+    pub port: u16,
     pub username: String,
     pub connection_timeout: Duration,
     pub connection_attempts: usize,
@@ -30,10 +32,13 @@ impl Config {
 
     /// Create `Config` from `HostParams` and `SshOpts`
     fn from_params(params: HostParams, opts: &SshOpts) -> Self {
+        let resolved_host = Self::resolve_host(&params, opts);
+        let port = Self::resolve_port(&params, opts);
         Config {
             host: opts.host.to_string(),
-            resolved_host: Self::resolve_host(&params, opts),
-            address: Self::resolve_address(&params, opts),
+            address: Self::format_address(&resolved_host, port),
+            resolved_host,
+            port,
             username: Self::resolve_username(&params, opts),
             connection_timeout: Self::resolve_connection_timeout(&params, opts),
             connection_attempts: Self::resolve_connection_attempts(&params),
@@ -70,15 +75,20 @@ impl Config {
         }
     }
 
-    /// Given host params and ssh options, returns resolved remote address
-    fn resolve_address(params: &HostParams, opts: &SshOpts) -> String {
-        let host = Self::resolve_host(params, opts);
+    fn resolve_port(params: &HostParams, opts: &SshOpts) -> u16 {
         // Opts.port has priority
-        let port = match opts.port {
+        match opts.port {
             None => params.port.unwrap_or(22),
             Some(p) => p,
-        };
-        format!("{host}:{port}")
+        }
+    }
+
+    fn format_address(host: &str, port: u16) -> String {
+        if host.contains(':') && !host.starts_with('[') {
+            format!("[{host}]:{port}")
+        } else {
+            format!("{host}:{port}")
+        }
     }
 
     /// Resolve username from opts and params.
@@ -107,6 +117,120 @@ impl Config {
     fn resolve_connection_attempts(params: &HostParams) -> usize {
         params.connection_attempts.unwrap_or(1)
     }
+
+    /// Resolve each configured jump host using the same SSH configuration file.
+    pub fn proxy_jump_configs(&self, opts: &SshOpts) -> RemoteResult<Vec<Self>> {
+        let Some(proxy_jumps) = self.params.proxy_jump.as_deref() else {
+            return Ok(Vec::new());
+        };
+        if proxy_jumps.len() == 1 && proxy_jumps[0].eq_ignore_ascii_case("none") {
+            return Ok(Vec::new());
+        }
+
+        proxy_jumps
+            .iter()
+            .map(|proxy_jump| {
+                let spec = ProxyJumpSpec::parse(proxy_jump)?;
+                let mut params = if let Some(config_file) = opts.config_file.as_deref() {
+                    Self::parse(config_file, &spec.host, opts.parse_rules)?
+                } else {
+                    HostParams::new(&DefaultAlgorithms::default())
+                };
+                // A comma-separated ProxyJump list already describes the complete
+                // chain. Do not recursively apply a jump host's own ProxyJump.
+                params.proxy_jump = None;
+                let resolved_host = params
+                    .host_name
+                    .clone()
+                    .unwrap_or_else(|| spec.host.clone());
+                let port = spec.port.or(params.port).unwrap_or(22);
+                if port == 0 {
+                    return Err(ProxyJumpSpec::invalid(proxy_jump));
+                }
+                let username = spec
+                    .user
+                    .clone()
+                    .or_else(|| params.user.clone())
+                    .unwrap_or_default();
+
+                Ok(Self {
+                    address: Self::format_address(&resolved_host, port),
+                    connection_attempts: Self::resolve_connection_attempts(&params),
+                    connection_timeout: Self::resolve_connection_timeout(&params, opts),
+                    host: spec.host,
+                    params,
+                    port,
+                    resolved_host,
+                    username,
+                })
+            })
+            .collect()
+    }
+}
+
+struct ProxyJumpSpec {
+    host: String,
+    port: Option<u16>,
+    user: Option<String>,
+}
+
+impl ProxyJumpSpec {
+    fn parse(value: &str) -> RemoteResult<Self> {
+        let value = value.strip_prefix("ssh://").unwrap_or(value);
+        if value.is_empty() || value.contains(['/', '?', '#']) {
+            return Err(Self::invalid(value));
+        }
+        let (user, host_and_port) = value
+            .rsplit_once('@')
+            .map_or((None, value), |(user, host)| (Some(user.to_string()), host));
+        if user.as_deref() == Some("") {
+            return Err(Self::invalid(value));
+        }
+
+        let (host, port) = if let Some(bracketed) = host_and_port.strip_prefix('[') {
+            let Some(closing_bracket) = bracketed.find(']') else {
+                return Err(Self::invalid(value));
+            };
+            let host = &bracketed[..closing_bracket];
+            let suffix = &bracketed[closing_bracket + 1..];
+            let port = match suffix.strip_prefix(':') {
+                Some(port) => Some(Self::parse_port(value, port)?),
+                None if suffix.is_empty() => None,
+                None => return Err(Self::invalid(value)),
+            };
+            (host, port)
+        } else if host_and_port.matches(':').count() == 1 {
+            let (host, port) = host_and_port
+                .rsplit_once(':')
+                .expect("checked delimiter count");
+            (host, Some(Self::parse_port(value, port)?))
+        } else {
+            (host_and_port, None)
+        };
+        if host.is_empty() {
+            return Err(Self::invalid(value));
+        }
+
+        Ok(Self {
+            host: host.to_string(),
+            port,
+            user,
+        })
+    }
+
+    fn parse_port(value: &str, port: &str) -> RemoteResult<u16> {
+        port.parse()
+            .ok()
+            .filter(|port| *port != 0)
+            .ok_or_else(|| Self::invalid(value))
+    }
+
+    fn invalid(value: &str) -> RemoteError {
+        RemoteError::new_ex(
+            RemoteErrorType::BadAddress,
+            format!("invalid ProxyJump destination '{value}'"),
+        )
+    }
 }
 
 impl TryFrom<&SshOpts> for Config {
@@ -125,8 +249,10 @@ impl TryFrom<&SshOpts> for Config {
 
 #[cfg(test)]
 mod test {
+    use std::io::Write as _;
 
     use pretty_assertions::{assert_eq, assert_ne};
+    use tempfile::NamedTempFile;
 
     use super::*;
     use crate::mock::ssh as ssh_mock;
@@ -200,5 +326,49 @@ mod test {
             config.params,
             HostParams::new(&DefaultAlgorithms::default())
         );
+    }
+
+    #[test]
+    fn should_parse_proxy_jump_destinations() {
+        let alias = ProxyJumpSpec::parse("jump").expect("failed to parse host alias");
+        assert_eq!(alias.host, "jump");
+        assert_eq!(alias.port, None);
+        assert_eq!(alias.user, None);
+
+        let destination = ProxyJumpSpec::parse("alice@jump.example.com:2222")
+            .expect("failed to parse jump destination");
+        assert_eq!(destination.host, "jump.example.com");
+        assert_eq!(destination.port, Some(2222));
+        assert_eq!(destination.user.as_deref(), Some("alice"));
+
+        let uri = ProxyJumpSpec::parse("ssh://alice@[2001:db8::1]:2200")
+            .expect("failed to parse jump URI");
+        assert_eq!(uri.host, "2001:db8::1");
+        assert_eq!(uri.port, Some(2200));
+        assert_eq!(uri.user.as_deref(), Some("alice"));
+    }
+
+    #[test]
+    fn should_reject_invalid_proxy_jump_destinations() {
+        assert!(ProxyJumpSpec::parse("").is_err());
+        assert!(ProxyJumpSpec::parse("alice@").is_err());
+        assert!(ProxyJumpSpec::parse("jump:0").is_err());
+        assert!(ProxyJumpSpec::parse("jump:invalid").is_err());
+        assert!(ProxyJumpSpec::parse("ssh://jump/path").is_err());
+        assert!(ProxyJumpSpec::parse("[2001:db8::1").is_err());
+    }
+
+    #[test]
+    fn should_reject_zero_port_from_proxy_jump_alias() {
+        let mut config_file = NamedTempFile::new().expect("failed to create SSH config");
+        writeln!(
+            config_file,
+            "Host target\n    ProxyJump jump\nHost jump\n    Port 0"
+        )
+        .expect("failed to write SSH config");
+        let opts = SshOpts::new("target").config_file(config_file.path(), ParseRule::STRICT);
+        let config = Config::try_from(&opts).expect("failed to parse destination config");
+
+        assert!(config.proxy_jump_configs(&opts).is_err());
     }
 }

--- a/src/ssh/config.rs
+++ b/src/ssh/config.rs
@@ -265,6 +265,7 @@ mod test {
         assert_eq!(config.connection_timeout, Duration::from_secs(30));
         assert_eq!(config.address.as_str(), "192.168.1.1:22");
         assert_eq!(config.host.as_str(), "192.168.1.1");
+        assert_eq!(config.port, 22);
         assert!(config.username.is_empty());
         assert_eq!(
             config.params,
@@ -283,6 +284,7 @@ mod test {
         assert_eq!(config.connection_timeout, Duration::from_secs(10));
         assert_eq!(config.host.as_str(), "192.168.1.1");
         assert_eq!(config.address.as_str(), "192.168.1.1:2222");
+        assert_eq!(config.port, 2222);
         assert_eq!(config.username.as_str(), "omar");
         assert_eq!(
             config.params,
@@ -292,14 +294,15 @@ mod test {
 
     #[test]
     fn should_init_config_from_file() {
-        let config_file = ssh_mock::create_ssh_config(22);
+        let config_file = ssh_mock::create_ssh_config(2222);
         let opts = SshOpts::new("sftp").config_file(config_file.path(), ParseRule::STRICT);
         let config = Config::try_from(&opts).ok().unwrap();
         assert_eq!(config.connection_attempts, 3);
         assert_eq!(config.connection_timeout, Duration::from_secs(60));
         assert_eq!(config.host.as_str(), "sftp");
         assert_eq!(config.resolved_host.as_str(), "127.0.0.1");
-        assert_eq!(config.address.as_str(), "127.0.0.1:22");
+        assert_eq!(config.address.as_str(), "127.0.0.1:2222");
+        assert_eq!(config.port, 2222);
         assert_eq!(config.username.as_str(), "sftp");
         assert_ne!(
             config.params,
@@ -309,23 +312,35 @@ mod test {
 
     #[test]
     fn should_init_config_from_file_with_override() {
-        let config_file = ssh_mock::create_ssh_config(22);
+        let config_file = ssh_mock::create_ssh_config(2222);
         let opts = SshOpts::new("sftp")
             .config_file(config_file.path(), ParseRule::STRICT)
             .connection_timeout(Duration::from_secs(10))
-            .port(22)
+            .port(2200)
             .username("omar");
         let config = Config::try_from(&opts).ok().unwrap();
         assert_eq!(config.connection_attempts, 3);
         assert_eq!(config.connection_timeout, Duration::from_secs(10));
         assert_eq!(config.host.as_str(), "sftp");
         assert_eq!(config.resolved_host.as_str(), "127.0.0.1");
-        assert_eq!(config.address.as_str(), "127.0.0.1:22");
+        assert_eq!(config.address.as_str(), "127.0.0.1:2200");
+        assert_eq!(config.port, 2200);
         assert_eq!(config.username.as_str(), "omar");
         assert_ne!(
             config.params,
             HostParams::new(&DefaultAlgorithms::default())
         );
+    }
+
+    #[test]
+    fn should_format_ipv6_address() {
+        let opts = SshOpts::new("2001:db8::1").port(2222);
+
+        let config = Config::try_from(&opts).expect("failed to resolve SSH config");
+
+        assert_eq!(config.address.as_str(), "[2001:db8::1]:2222");
+        assert_eq!(config.resolved_host.as_str(), "2001:db8::1");
+        assert_eq!(config.port, 2222);
     }
 
     #[test]

--- a/src/ssh/container.rs
+++ b/src/ssh/container.rs
@@ -1,8 +1,11 @@
 use std::borrow::Cow;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
-use testcontainers::core::{ContainerPort, WaitFor};
-use testcontainers::{Container, Image};
+use testcontainers::core::{CmdWaitFor, ContainerPort, ExecCommand, WaitFor};
+use testcontainers::{Container, Image, ImageExt as _};
+
+static PROXY_JUMP_NETWORK_ID: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Debug, Clone)]
 struct OpensshServerImage {
@@ -75,10 +78,71 @@ impl OpensshServer {
         Self { container }
     }
 
+    fn start_in_network(network: &str, container_name: Option<&str>) -> Self {
+        use testcontainers::runners::SyncRunner;
+
+        let request = OpensshServerImage::default().with_network(network);
+        let container = match container_name {
+            Some(container_name) => request.with_container_name(container_name).start(),
+            None => request.start(),
+        }
+        .expect("Failed to start container in proxy jump network");
+
+        Self { container }
+    }
+
     pub fn port(&self) -> u16 {
         std::thread::sleep(Duration::from_secs(5));
         self.container
             .get_host_port_ipv4(2222)
             .expect("Failed to get port")
+    }
+
+    fn enable_tcp_forwarding(&self) {
+        let command = ExecCommand::new([
+            "sh",
+            "-c",
+            "sed -i 's/^AllowTcpForwarding no$/AllowTcpForwarding yes/' /config/sshd/sshd_config && kill -HUP $(pgrep -o sshd)",
+        ])
+        .with_cmd_ready_condition(CmdWaitFor::exit_code(0));
+        let result = self
+            .container
+            .exec(command)
+            .expect("Failed to enable TCP forwarding on jump server");
+        assert_eq!(
+            result.exit_code().expect("Failed to read setup exit code"),
+            Some(0),
+            "Could not enable TCP forwarding on jump server"
+        );
+    }
+}
+
+pub struct ProxyJumpServers {
+    pub _target: OpensshServer,
+    pub _second_jump: OpensshServer,
+    pub first_jump: OpensshServer,
+    pub second_jump_host: String,
+    pub target_host: String,
+}
+
+impl ProxyJumpServers {
+    pub fn start() -> Self {
+        let id = PROXY_JUMP_NETWORK_ID.fetch_add(1, Ordering::Relaxed);
+        let network = format!("remotefs-proxy-{}-{id}", std::process::id());
+        let target_host = format!("remotefs-target-{}-{id}", std::process::id());
+        let second_jump_host = format!("remotefs-jump-{}-{id}", std::process::id());
+        let target = OpensshServer::start_in_network(&network, Some(&target_host));
+        let second_jump = OpensshServer::start_in_network(&network, Some(&second_jump_host));
+        second_jump.enable_tcp_forwarding();
+        let first_jump = OpensshServer::start_in_network(&network, None);
+        first_jump.enable_tcp_forwarding();
+
+        Self {
+            _target: target,
+            _second_jump: second_jump,
+            first_jump,
+            second_jump_host,
+            target_host,
+        }
     }
 }

--- a/src/ssh/container.rs
+++ b/src/ssh/container.rs
@@ -4,8 +4,18 @@ use std::time::Duration;
 use testcontainers::core::{ContainerPort, WaitFor};
 use testcontainers::{Container, Image};
 
-#[derive(Debug, Default, Clone)]
-struct OpensshServerImage;
+#[derive(Debug, Clone)]
+struct OpensshServerImage {
+    public_key: String,
+}
+
+impl Default for OpensshServerImage {
+    fn default() -> Self {
+        Self {
+            public_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDErJhQxEI0+VvhlXVUyh+vMCm7aXfCA/g633AG8ezD/5EylwchtAr2JCoBWnxn4zV8nI9dMqOgm0jO4IsXpKOjQojv+0VOH7I+cDlBg0tk4hFlvyyS6YviDAfDDln3jYUM+5QNDfQLaZlH2WvcJ3mkDxLVlI9MBX1BAeSmChLxwAvxALp2ncImNQLzDO9eHcig3dtMrEKkzXQowRW5Y7eUzg2+vvVq4H2DOjWwUndvB5sJkhEfTUVE7ID8ZdGJo60kUb/02dZYj+IbkAnMCsqktk0cg/4XFX82hEfRYFeb1arkysFisPU1DOb6QielL/axeTebVplaouYcXY0pFdJt root@8c50fd4c345a".to_string(),
+        }
+    }
+}
 
 impl Image for OpensshServerImage {
     fn name(&self) -> &str {
@@ -36,10 +46,7 @@ impl Image for OpensshServerImage {
             ("TZ", "Europe/London"),
             ("SUDO_ACCESS", "false"),
             ("PASSWORD_ACCESS", "true"),
-            (
-                "PUBLIC_KEY",
-                "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDErJhQxEI0+VvhlXVUyh+vMCm7aXfCA/g633AG8ezD/5EylwchtAr2JCoBWnxn4zV8nI9dMqOgm0jO4IsXpKOjQojv+0VOH7I+cDlBg0tk4hFlvyyS6YviDAfDDln3jYUM+5QNDfQLaZlH2WvcJ3mkDxLVlI9MBX1BAeSmChLxwAvxALp2ncImNQLzDO9eHcig3dtMrEKkzXQowRW5Y7eUzg2+vvVq4H2DOjWwUndvB5sJkhEfTUVE7ID8ZdGJo60kUb/02dZYj+IbkAnMCsqktk0cg/4XFX82hEfRYFeb1arkysFisPU1DOb6QielL/axeTebVplaouYcXY0pFdJt root@8c50fd4c345a",
-            ),
+            ("PUBLIC_KEY", self.public_key.as_str()),
             ("USER_PASSWORD", "password"),
             ("USER_NAME", "sftp"),
         ]
@@ -52,10 +59,18 @@ pub struct OpensshServer {
 
 impl OpensshServer {
     pub fn start() -> Self {
+        Self::start_with_image(OpensshServerImage::default())
+    }
+
+    pub fn start_with_public_key(public_key: &str) -> Self {
+        Self::start_with_image(OpensshServerImage {
+            public_key: public_key.to_string(),
+        })
+    }
+
+    fn start_with_image(image: OpensshServerImage) -> Self {
         use testcontainers::runners::SyncRunner;
-        let container = OpensshServerImage
-            .start()
-            .expect("Failed to start container");
+        let container = image.start().expect("Failed to start container");
 
         Self { container }
     }

--- a/src/ssh/container.rs
+++ b/src/ssh/container.rs
@@ -65,6 +65,12 @@ impl OpensshServer {
         Self::start_with_image(OpensshServerImage::default())
     }
 
+    pub fn start_with_tcp_forwarding() -> Self {
+        let server = Self::start();
+        server.enable_tcp_forwarding();
+        server
+    }
+
     pub fn start_with_public_key(public_key: &str) -> Self {
         Self::start_with_image(OpensshServerImage {
             public_key: public_key.to_string(),


### PR DESCRIPTION
## What changed

SSH configuration options are now applied consistently across the russh, libssh, and libssh2 clients. This includes host names, connection settings, key selection, proxy jumps, keepalives, agent forwarding, and remote forwarding. Remote forwarding supports fixed destinations, dynamic SOCKS proxies, Unix sockets where the backend permits them, and server-assigned ports.

## Why

Several exposed ssh2-config options were parsed but not used by one or more clients. This caused surprising connection behavior, especially for host names and authentication keys. The clients now honor every option that their backend can implement and return clear errors for unsupported forms.

## Notes

Each option was implemented and verified in its own commit. The full just check quality gate passes. Remote Unix listeners remain unavailable with libssh and libssh2 because those libraries do not expose the required API.